### PR TITLE
Make the site findable and its links shareable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,13 @@ jobs:
             - name: Typecheck
               run: npm run typecheck
 
+            # Covers the pure logic worth protecting — currently the map URL
+            # hash, whose clamping, wrapping and empty-segment handling are easy
+            # to get subtly wrong and produce links that silently land somewhere
+            # else. Three real bugs were caught writing these.
+            - name: Test
+              run: npm test
+
             # This step deliberately runs with no secrets in scope.
             #
             # A module that threw on a missing environment variable once broke the

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,8 @@
                 "eslint-config-prettier": "^10.1.1",
                 "prettier": "^3.5.3",
                 "tailwindcss": "^4",
-                "typescript": "^5"
+                "typescript": "^5",
+                "vitest": "^4.1.10"
             }
         },
         "node_modules/@alloc/quick-lru": {
@@ -762,6 +763,13 @@
                 "url": "https://opencollective.com/libvips"
             }
         },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@kurkle/color": {
             "version": "0.3.4",
             "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
@@ -987,6 +995,16 @@
                 "node": ">=12.4.0"
             }
         },
+        "node_modules/@oxc-project/types": {
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+            "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
         "node_modules/@react-leaflet/core": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
@@ -997,6 +1015,251 @@
                 "react": "^19.0.0",
                 "react-dom": "^19.0.0"
             }
+        },
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
+            "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
+            "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
+            "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
+            "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
+            "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
+            "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
+            "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
+            "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
+            "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
+            "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
+            "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
+            "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
+            "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
+            "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+            "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@rtsao/scc": {
             "version": "1.1.0",
@@ -1009,6 +1272,13 @@
             "version": "1.11.0",
             "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.11.0.tgz",
             "integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
             "dev": true,
             "license": "MIT"
         },
@@ -1268,6 +1538,24 @@
             "dependencies": {
                 "tslib": "^2.4.0"
             }
+        },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/estree": {
             "version": "1.0.6",
@@ -1752,6 +2040,92 @@
                 "win32"
             ]
         },
+        "node_modules/@vitest/expect": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+            "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+            "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+            "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.10",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+            "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+            "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+            "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
         "node_modules/acorn": {
             "version": "8.18.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
@@ -1983,6 +2357,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/ast-types-flow": {
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -2147,6 +2531,16 @@
             ],
             "license": "CC-BY-4.0"
         },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2214,6 +2608,13 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
             "dev": true,
             "license": "MIT"
         },
@@ -2542,6 +2943,13 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
@@ -3044,6 +3452,16 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3052,6 +3470,16 @@
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/expect-type": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+            "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/fast-deep-equal": {
@@ -3198,6 +3626,21 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
         "node_modules/function-bind": {
@@ -4116,6 +4559,27 @@
                 "lightningcss-win32-x64-msvc": "1.29.2"
             }
         },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+            "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
         "node_modules/lightningcss-darwin-arm64": {
             "version": "1.29.2",
             "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.29.2.tgz",
@@ -4360,6 +4824,16 @@
             },
             "bin": {
                 "loose-envify": "cli.js"
+            }
+        },
+        "node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
             }
         },
         "node_modules/math-intrinsics": {
@@ -4660,6 +5134,20 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/obug": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+            "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.20.0"
+            }
+        },
         "node_modules/optionator": {
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4765,6 +5253,13 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
             "dev": true,
             "license": "MIT"
         },
@@ -5085,6 +5580,39 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/rolldown": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
+            "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "=0.143.0",
+                "@rolldown/pluginutils": "^1.0.0"
+            },
+            "bin": {
+                "rolldown": "bin/cli.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "optionalDependencies": {
+                "@rolldown/binding-android-arm64": "1.2.3",
+                "@rolldown/binding-darwin-arm64": "1.2.3",
+                "@rolldown/binding-darwin-x64": "1.2.3",
+                "@rolldown/binding-freebsd-x64": "1.2.3",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
+                "@rolldown/binding-linux-arm64-gnu": "1.2.3",
+                "@rolldown/binding-linux-arm64-musl": "1.2.3",
+                "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
+                "@rolldown/binding-linux-s390x-gnu": "1.2.3",
+                "@rolldown/binding-linux-x64-gnu": "1.2.3",
+                "@rolldown/binding-linux-x64-musl": "1.2.3",
+                "@rolldown/binding-openharmony-arm64": "1.2.3",
+                "@rolldown/binding-win32-arm64-msvc": "1.2.3",
+                "@rolldown/binding-win32-x64-msvc": "1.2.3"
+            }
+        },
         "node_modules/rspack-resolver": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/rspack-resolver/-/rspack-resolver-1.1.0.tgz",
@@ -5399,6 +5927,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/source-map-js": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5412,6 +5947,20 @@
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
             "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+            "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
             "dev": true,
             "license": "MIT"
         },
@@ -5617,15 +6166,32 @@
                 "node": ">=6"
             }
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+            "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/tinyglobby": {
-            "version": "0.2.12",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
-            "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "fdir": "^6.4.3",
-                "picomatch": "^4.0.2"
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -5635,11 +6201,14 @@
             }
         },
         "node_modules/tinyglobby/node_modules/fdir": {
-            "version": "6.4.3",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
-            "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
             "peerDependencies": {
                 "picomatch": "^3 || ^4"
             },
@@ -5660,6 +6229,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+            "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/to-regex-range": {
@@ -5848,6 +6427,454 @@
                 "punycode": "^2.1.0"
             }
         },
+        "node_modules/vitest": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+            "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "4.1.10",
+                "@vitest/mocker": "4.1.10",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/runner": "4.1.10",
+                "@vitest/snapshot": "4.1.10",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.10",
+                "@vitest/browser-preview": "4.1.10",
+                "@vitest/browser-webdriverio": "4.1.10",
+                "@vitest/coverage-istanbul": "4.1.10",
+                "@vitest/coverage-v8": "4.1.10",
+                "@vitest/ui": "4.1.10",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/@vitest/mocker": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+            "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.10",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/lightningcss": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+            "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.33.0",
+                "lightningcss-darwin-arm64": "1.33.0",
+                "lightningcss-darwin-x64": "1.33.0",
+                "lightningcss-freebsd-x64": "1.33.0",
+                "lightningcss-linux-arm-gnueabihf": "1.33.0",
+                "lightningcss-linux-arm64-gnu": "1.33.0",
+                "lightningcss-linux-arm64-musl": "1.33.0",
+                "lightningcss-linux-x64-gnu": "1.33.0",
+                "lightningcss-linux-x64-musl": "1.33.0",
+                "lightningcss-win32-arm64-msvc": "1.33.0",
+                "lightningcss-win32-x64-msvc": "1.33.0"
+            }
+        },
+        "node_modules/vitest/node_modules/lightningcss-darwin-arm64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+            "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vitest/node_modules/lightningcss-darwin-x64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+            "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vitest/node_modules/lightningcss-freebsd-x64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+            "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vitest/node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+            "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vitest/node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+            "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vitest/node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+            "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vitest/node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+            "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vitest/node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+            "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vitest/node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+            "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vitest/node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+            "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vitest/node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/vitest/node_modules/vite": {
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+            "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lightningcss": "^1.33.0",
+                "picomatch": "^4.0.5",
+                "postcss": "^8.5.25",
+                "rolldown": "~1.2.1",
+                "tinyglobby": "^0.2.17"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.4.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5951,6 +6978,23 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/wkt-parser": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
         "lint": "eslint . --max-warnings 0",
         "typecheck": "tsc --noEmit",
         "format": "prettier --write .",
-        "format:check": "prettier --check ."
+        "format:check": "prettier --check .",
+        "test": "vitest run",
+        "test:watch": "vitest"
     },
     "dependencies": {
         "@mapbox/vector-tile": "^2.0.4",
@@ -41,6 +43,7 @@
         "eslint-config-prettier": "^10.1.1",
         "prettier": "^3.5.3",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.1.10"
     }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,6 +16,7 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
+import { SITE_DESCRIPTION, SITE_NAME, SITE_URL } from '@/lib/site';
 
 // Configuration of Geist fonts (sans-serif) and Geist Mono (monospace)
 // These fonts will be available via CSS variables --font-geist-sans and --font-geist-mono
@@ -29,11 +30,43 @@ const geistMono = Geist_Mono({
     subsets: ['latin'],
 });
 
-// Application metadata (title, description)
 export const metadata: Metadata = {
-    title: 'StreetRadar - Interactive Street View Coverage Map',
-    description:
-        'Discover Street View coverage worldwide. Find panoramas from Google, Bing, Yandex and Apple in one place.',
+    // metadataBase makes Next resolve opengraph-image and other assets to
+    // absolute URLs. Without it they are emitted relative, and crawlers that
+    // fetch the card out of context cannot follow them.
+    metadataBase: new URL(SITE_URL),
+    title: {
+        default: 'StreetRadar — Street View Coverage Map',
+        template: '%s — StreetRadar',
+    },
+    description: SITE_DESCRIPTION,
+    applicationName: SITE_NAME,
+    keywords: [
+        'street view coverage',
+        'street view coverage map',
+        'apple look around coverage',
+        'bing streetside coverage',
+        'yandex panoramas coverage',
+        'naver street view coverage',
+        'já 360 coverage',
+        'panorama coverage map',
+    ],
+    alternates: {
+        canonical: '/',
+    },
+    openGraph: {
+        type: 'website',
+        siteName: SITE_NAME,
+        title: 'StreetRadar — Street View Coverage Map',
+        description: SITE_DESCRIPTION,
+        url: SITE_URL,
+        locale: 'en_US',
+    },
+    twitter: {
+        card: 'summary_large_image',
+        title: 'StreetRadar — Street View Coverage Map',
+        description: SITE_DESCRIPTION,
+    },
     icons: {
         icon: '/images/logo_no_bg.png',
         shortcut: '/images/logo_no_bg.png',

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,99 @@
+/**
+ * opengraph-image.tsx
+ *
+ * Generates the preview card for shares on Reddit, Discord, Slack and X.
+ *
+ * The site had no Open Graph tags at all, so every link to it rendered as bare
+ * text. For a product whose whole value is visual, that quietly killed sharing
+ * in exactly the communities most likely to care.
+ *
+ * Drawn rather than served as a static file so the provider list and coverage
+ * date stay in step with the code.
+ */
+
+import { ImageResponse } from 'next/og';
+import { SITE_NAME, formatCoverageMonth, oldestCoverageDate } from '@/lib/site';
+
+export const alt = 'StreetRadar — Street View coverage from six providers on one map';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+// The palette the site already uses, from globals.css.
+const BACKGROUND = '#fefbf1';
+const PRIMARY = '#9b4434';
+const SECONDARY = '#337b81';
+const TEXT = '#333333';
+const TEXT_LIGHT = '#666666';
+
+const PROVIDERS = ['Google', 'Apple', 'Bing', 'Yandex', 'Naver', 'Já 360'];
+
+export default async function Image() {
+    return new ImageResponse(
+        (
+            <div
+                style={{
+                    width: '100%',
+                    height: '100%',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    justifyContent: 'space-between',
+                    background: BACKGROUND,
+                    padding: '72px 80px',
+                }}
+            >
+                {/* A hairline of the two brand colours across the top */}
+                <div style={{ display: 'flex', height: 8, width: '100%' }}>
+                    <div style={{ flex: 1, background: PRIMARY }} />
+                    <div style={{ flex: 1, background: SECONDARY }} />
+                </div>
+
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+                    <div
+                        style={{
+                            fontSize: 92,
+                            fontWeight: 700,
+                            color: PRIMARY,
+                            letterSpacing: '-0.03em',
+                        }}
+                    >
+                        {SITE_NAME}
+                    </div>
+                    <div
+                        style={{
+                            fontSize: 38,
+                            color: TEXT,
+                            lineHeight: 1.3,
+                            maxWidth: 900,
+                        }}
+                    >
+                        See where Street View imagery exists worldwide — six providers on one map.
+                    </div>
+                </div>
+
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+                    <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+                        {PROVIDERS.map((name) => (
+                            <div
+                                key={name}
+                                style={{
+                                    display: 'flex',
+                                    fontSize: 26,
+                                    color: SECONDARY,
+                                    border: `2px solid ${SECONDARY}`,
+                                    borderRadius: 999,
+                                    padding: '8px 22px',
+                                }}
+                            >
+                                {name}
+                            </div>
+                        ))}
+                    </div>
+                    <div style={{ display: 'flex', fontSize: 24, color: TEXT_LIGHT }}>
+                        streetradar.app · coverage data {formatCoverageMonth(oldestCoverageDate())}
+                    </div>
+                </div>
+            </div>
+        ),
+        size
+    );
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,23 @@
+/**
+ * robots.ts
+ *
+ * There was no robots.txt of our own — the one being served came from
+ * Cloudflare's managed default. This replaces it with something that names the
+ * sitemap, which is how a crawler finds it without being told.
+ *
+ * Nothing is disallowed: every route here is public and meant to be indexed.
+ */
+
+import type { MetadataRoute } from 'next';
+import { SITE_URL } from '@/lib/site';
+
+export default function robots(): MetadataRoute.Robots {
+    return {
+        rules: {
+            userAgent: '*',
+            allow: '/',
+        },
+        sitemap: `${SITE_URL}/sitemap.xml`,
+        host: SITE_URL,
+    };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,31 @@
+/**
+ * sitemap.ts
+ *
+ * The site had no sitemap at all — /sitemap.xml returned 404 — which is part of
+ * why Google sends no traffic while Bing does. Three URLs is a small sitemap,
+ * but it is the difference between "crawlable" and "invisible", and it is what
+ * per-country pages will extend once the coverage data is fresh again.
+ */
+
+import type { MetadataRoute } from 'next';
+import { SITE_URL } from '@/lib/site';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+    return [
+        {
+            url: SITE_URL,
+            changeFrequency: 'monthly',
+            priority: 1,
+        },
+        {
+            url: `${SITE_URL}/map`,
+            changeFrequency: 'monthly',
+            priority: 0.9,
+        },
+        {
+            url: `${SITE_URL}/analytics`,
+            changeFrequency: 'monthly',
+            priority: 0.6,
+        },
+    ];
+}

--- a/src/components/map/mapContainer.tsx
+++ b/src/components/map/mapContainer.tsx
@@ -9,6 +9,9 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+
+import { readMapHash, useMapUrlState } from '@/hooks/useMapUrlState';
+import type { Basemap } from '@/lib/mapUrlState';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import '@/styles/leafletStyles.css';
@@ -39,19 +42,36 @@ export default function MapContainer({
     const mapRef = useRef<HTMLDivElement>(null);
     // Leaflet map instance
     const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
+
+    // The view carried by the URL, if any. Read once at mount: this component
+    // is loaded with ssr: false, so window is available during render.
+    const initialUrlState = useRef(readMapHash()).current;
+
     // Visible layers state
-    const [visibleLayers, setVisibleLayers] = useState({
-        googleStreetView: true,
-        bingStreetside: true,
-        yandexPanoramas: false,
-        appleLookAround: false,
-        naverStreetView: false,
-        jaStreetView: false,
+    const [visibleLayers, setVisibleLayers] = useState(() => {
+        const defaults = {
+            googleStreetView: true,
+            bingStreetside: true,
+            yandexPanoramas: false,
+            appleLookAround: false,
+            naverStreetView: false,
+            jaStreetView: false,
+        };
+
+        // A link with no layer section keeps the defaults; one that lists none
+        // meant it, and gets an empty map.
+        if (!initialUrlState?.layers) return defaults;
+
+        const fromUrl = { ...defaults };
+        for (const key of Object.keys(fromUrl) as (keyof typeof fromUrl)[]) {
+            fromUrl[key] = initialUrlState.layers.includes(key);
+        }
+        return fromUrl;
     });
     // Control panel collapsed state
     const [isPanelCollapsed, setIsPanelCollapsed] = useState(false);
     // Basemap selection
-    const [currentBasemap, setCurrentBasemap] = useState('osm');
+    const [currentBasemap, setCurrentBasemap] = useState(initialUrlState?.basemap ?? 'osm');
     // Basemap selector open state
     const [isBasemapSelectorOpen, setIsBasemapSelectorOpen] = useState(false);
     // References to the basemap layers
@@ -82,6 +102,9 @@ export default function MapContainer({
     const [appleWarningShown, setAppleWarningShown] = useState<boolean>(false);
     // Statistics panel open state
     const [isStatisticsPanelOpen, setIsStatisticsPanelOpen] = useState<boolean>(false);
+
+    // Mirror the current view into the URL hash so a position can be shared.
+    useMapUrlState({ map: mapInstance, visibleLayers, basemap: currentBasemap });
 
     // Minimum zoom level to activate Street View - reduced by 6 levels total (16 -> 13 -> 10)
     const MIN_ZOOM_FOR_STREETVIEW = 10;
@@ -149,7 +172,10 @@ export default function MapContainer({
         const map = L.map(mapRef.current, {
             maxZoom: 19,
             zoomControl: false, // Disable default zoom control to reposition it
-        }).setView(center, zoom);
+        }).setView(
+            initialUrlState ? [initialUrlState.lat, initialUrlState.lon] : center,
+            initialUrlState ? initialUrlState.zoom : zoom
+        );
 
         // Add our custom CSS class to the map container
         map.getContainer().className += ' streetradar-map';
@@ -217,13 +243,23 @@ export default function MapContainer({
             })
             .addTo(map);
 
+        // A shared link can name a basemap other than the OSM default added
+        // above; apply it once the layer refs exist.
+        if (initialUrlState && initialUrlState.basemap !== 'osm') {
+            const chosen = basemapLayersRef.current[initialUrlState.basemap];
+            map.removeLayer(osm);
+            if (chosen) chosen.addTo(map);
+        }
+
         setMapInstance(map);
 
         // Cleanup on unmount
         return () => {
             map.remove();
         };
-    }, [center, zoom]);
+        // initialUrlState is a useRef().current and never changes identity;
+        // it is listed to satisfy exhaustive-deps, not because it can vary.
+    }, [center, zoom, initialUrlState]);
 
     // Effect to manage map cursor based on zoom level
     useEffect(() => {
@@ -330,7 +366,7 @@ export default function MapContainer({
     };
 
     // Function to change basemap
-    const changeBasemap = (basemap: string) => {
+    const changeBasemap = (basemap: Basemap) => {
         if (!mapInstance || !basemapLayersRef.current) return;
 
         // Remove all basemap layers

--- a/src/hooks/useMapUrlState.ts
+++ b/src/hooks/useMapUrlState.ts
@@ -1,0 +1,75 @@
+/**
+ * useMapUrlState.ts
+ *
+ * Keeps the URL hash in step with what the map is showing.
+ *
+ * Writes use replaceState rather than pushState: panning a map generates a
+ * continuous stream of view changes, and pushing each one would make the back
+ * button walk through hundreds of intermediate positions instead of leaving
+ * the page.
+ */
+
+'use client';
+
+import { useEffect, useRef } from 'react';
+import type L from 'leaflet';
+import {
+    type Basemap,
+    type MapUrlState,
+    enabledLayerKeys,
+    formatMapHash,
+    parseMapHash,
+} from '@/lib/mapUrlState';
+
+/**
+ * Reads the view out of the current URL.
+ *
+ * Safe during SSR: returns null when there is no window, so the caller falls
+ * back to its default view.
+ */
+export function readMapHash(): MapUrlState | null {
+    if (typeof window === 'undefined') return null;
+    return parseMapHash(window.location.hash);
+}
+
+interface Options {
+    map: L.Map | null;
+    visibleLayers: Record<string, boolean>;
+    basemap: string;
+}
+
+export function useMapUrlState({ map, visibleLayers, basemap }: Options): void {
+    // Holds the last hash we wrote, so the hashchange listener can tell our own
+    // writes apart from a user editing the address bar or hitting back.
+    const lastWritten = useRef<string>('');
+
+    useEffect(() => {
+        if (!map) return;
+
+        const write = () => {
+            const center = map.getCenter();
+            const hash = formatMapHash({
+                zoom: map.getZoom(),
+                lat: center.lat,
+                lon: center.lng,
+                layers: enabledLayerKeys(visibleLayers),
+                basemap: basemap as Basemap,
+            });
+
+            if (hash === lastWritten.current) return;
+            lastWritten.current = hash;
+
+            window.history.replaceState(null, '', `${window.location.pathname}${hash}`);
+        };
+
+        write();
+
+        // moveend covers panning and zooming; layeradd/layerremove would fire
+        // far too often, so layer changes come in through the effect deps.
+        map.on('moveend', write);
+
+        return () => {
+            map.off('moveend', write);
+        };
+    }, [map, visibleLayers, basemap]);
+}

--- a/src/lib/mapUrlState.test.ts
+++ b/src/lib/mapUrlState.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import { type MapUrlState, enabledLayerKeys, formatMapHash, parseMapHash } from './mapUrlState';
+
+describe('parseMapHash', () => {
+    it('reads a full hash', () => {
+        expect(parseMapHash('#12/48.85341/2.34878/apple,google/satellite')).toEqual({
+            zoom: 12,
+            lat: 48.85341,
+            lon: 2.34878,
+            layers: ['appleLookAround', 'googleStreetView'],
+            basemap: 'satellite',
+        });
+    });
+
+    it('works without the leading hash', () => {
+        expect(parseMapHash('5/0/0/ja/osm')?.zoom).toBe(5);
+    });
+
+    it.each(['', '#', '   ', '#not/a/hash', '#12//2', '#/48/2'])(
+        'returns null for unusable input: %j',
+        (hash) => {
+            expect(parseMapHash(hash)).toBeNull();
+        }
+    );
+
+    it('distinguishes an absent layer section from an empty one', () => {
+        // No section at all: the caller keeps its defaults.
+        expect(parseMapHash('#12/48/2')?.layers).toBeNull();
+        // Section present but empty: the link deliberately turned everything off.
+        expect(parseMapHash('#12/48/2//osm')?.layers).toEqual([]);
+    });
+
+    it('drops unknown layer slugs rather than failing', () => {
+        expect(parseMapHash('#12/48/2/apple,notaprovider,ja')?.layers).toEqual([
+            'appleLookAround',
+            'jaStreetView',
+        ]);
+    });
+
+    it('falls back to osm for an unknown basemap', () => {
+        expect(parseMapHash('#12/48/2/apple/hologram')?.basemap).toBe('osm');
+    });
+
+    it('clamps zoom to what the map supports', () => {
+        expect(parseMapHash('#99/48/2')?.zoom).toBe(19);
+        expect(parseMapHash('#-5/48/2')?.zoom).toBe(1);
+    });
+
+    it('clamps latitude to the Web Mercator limit', () => {
+        // Beyond ~85 degrees the projection has no meaning and Leaflet clamps too.
+        expect(parseMapHash('#3/89/2')?.lat).toBeCloseTo(85.05112878, 5);
+        expect(parseMapHash('#3/-89/2')?.lat).toBeCloseTo(-85.05112878, 5);
+    });
+
+    it('wraps longitude so a map panned round the world still links canonically', () => {
+        expect(parseMapHash('#3/48/190')?.lon).toBeCloseTo(-170, 5);
+        expect(parseMapHash('#3/48/-190')?.lon).toBeCloseTo(170, 5);
+        // 540 is 180 plus a full turn. It comes back as -180, which is the same
+        // meridian — the antimeridian has two spellings and this is the canonical one.
+        expect(parseMapHash('#3/48/540')?.lon).toBeCloseTo(-180, 5);
+    });
+});
+
+describe('formatMapHash', () => {
+    const base: MapUrlState = {
+        zoom: 12,
+        lat: 48.853409,
+        lon: 2.348783,
+        layers: ['googleStreetView', 'appleLookAround'],
+        basemap: 'osm',
+    };
+
+    it('emits zoom/lat/lon/layers/basemap', () => {
+        expect(formatMapHash(base)).toBe('#12/48.85341/2.34878/google,apple/osm');
+    });
+
+    it('orders slugs consistently regardless of the input order', () => {
+        const reversed = { ...base, layers: ['appleLookAround', 'googleStreetView'] as const };
+        expect(formatMapHash({ ...reversed, layers: [...reversed.layers] })).toBe(
+            formatMapHash(base)
+        );
+    });
+
+    it('emits an empty section when no layer is on', () => {
+        expect(formatMapHash({ ...base, layers: [] })).toBe('#12/48.85341/2.34878//osm');
+    });
+
+    it('treats null layers as none', () => {
+        expect(formatMapHash({ ...base, layers: null })).toBe('#12/48.85341/2.34878//osm');
+    });
+});
+
+describe('round trip', () => {
+    it.each([
+        [12, 48.85341, 2.34878],
+        [1, 0, 0],
+        [19, -33.86882, 151.20929],
+        [8, 64.13548, -21.89541],
+    ])('survives parse(format(...)) at %i/%f/%f', (zoom, lat, lon) => {
+        const state: MapUrlState = {
+            zoom,
+            lat,
+            lon,
+            layers: ['naverStreetView'],
+            basemap: 'carto',
+        };
+        expect(parseMapHash(formatMapHash(state))).toEqual(state);
+    });
+});
+
+describe('enabledLayerKeys', () => {
+    it('returns only the layers that are on', () => {
+        expect(
+            enabledLayerKeys({
+                googleStreetView: true,
+                bingStreetside: false,
+                appleLookAround: true,
+            })
+        ).toEqual(['googleStreetView', 'appleLookAround']);
+    });
+
+    it('ignores keys that are not layers', () => {
+        expect(enabledLayerKeys({ somethingElse: true })).toEqual([]);
+    });
+});

--- a/src/lib/mapUrlState.ts
+++ b/src/lib/mapUrlState.ts
@@ -1,0 +1,137 @@
+/**
+ * mapUrlState.ts
+ *
+ * Encodes the map view in the URL hash so a position can be shared.
+ *
+ * Until now /map was a single URL for the entire planet: you could not link
+ * anyone to a place, and every visit started at the same default view. That is
+ * also why the site has three indexable URLs — there was nothing to index.
+ *
+ * Format:  #zoom/lat/lon/layers/basemap
+ * Example: #12/48.85341/2.34878/apple,google/osm
+ *
+ * The hash rather than a query string, deliberately: it is what every mapping
+ * site uses (OpenStreetMap, Google Maps, Mapy), so the shape is familiar, and
+ * updating it never round-trips to the server.
+ */
+
+/** URL slug -> the key used in the map's `visibleLayers` state. */
+export const LAYER_SLUGS = {
+    google: 'googleStreetView',
+    bing: 'bingStreetside',
+    yandex: 'yandexPanoramas',
+    apple: 'appleLookAround',
+    naver: 'naverStreetView',
+    ja: 'jaStreetView',
+} as const;
+
+export type LayerSlug = keyof typeof LAYER_SLUGS;
+export type LayerKey = (typeof LAYER_SLUGS)[LayerSlug];
+
+export const BASEMAPS = ['osm', 'carto', 'satellite', 'none'] as const;
+export type Basemap = (typeof BASEMAPS)[number];
+
+export interface MapUrlState {
+    zoom: number;
+    lat: number;
+    lon: number;
+    /**
+     * null when the link carried no layer section at all, which means "keep the
+     * defaults". An empty array is different: it means the link explicitly
+     * turned every overlay off, and must be honoured.
+     */
+    layers: LayerKey[] | null;
+    basemap: Basemap;
+}
+
+/** Web Mercator cannot represent the poles, and Leaflet clamps to this. */
+const MAX_LATITUDE = 85.05112878;
+
+/**
+ * Five decimals is a little over one metre — far finer than any coverage line
+ * is drawn, and short enough to keep shared links readable.
+ */
+const COORD_PRECISION = 5;
+
+function clamp(value: number, min: number, max: number): number {
+    return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Wraps longitude into [-180, 180] so a map panned several times round still
+ * produces a canonical link.
+ *
+ * The early return is not an optimisation: the modulo arithmetic loses the last
+ * digits of a float, so running it on a value already in range turned
+ * -21.89541 into -21.89540999999997 and broke the parse/format round trip.
+ */
+function wrapLongitude(lon: number): number {
+    if (lon >= -180 && lon <= 180) return lon;
+    return ((((lon + 180) % 360) + 360) % 360) - 180;
+}
+
+/**
+ * Parses a map hash. Returns null when it is absent or unusable, in which case
+ * the caller keeps its defaults — a malformed link should land on the world
+ * view, not an error.
+ */
+export function parseMapHash(hash: string): MapUrlState | null {
+    const raw = hash.replace(/^#/, '').trim();
+    if (!raw) return null;
+
+    const [zoomPart, latPart, lonPart, layersPart, basemapPart] = raw.split('/');
+
+    // Number('') is 0, not NaN, so an empty segment would silently read as a
+    // valid coordinate: '#12//2' would land on the equator instead of being
+    // rejected. Each part has to be present before it is converted.
+    const numeric = (part: string | undefined): number =>
+        part === undefined || part.trim() === '' ? Number.NaN : Number(part);
+
+    const zoom = numeric(zoomPart);
+    const lat = numeric(latPart);
+    const lon = numeric(lonPart);
+
+    if (!Number.isFinite(zoom) || !Number.isFinite(lat) || !Number.isFinite(lon)) {
+        return null;
+    }
+
+    const layers =
+        layersPart === undefined
+            ? null
+            : layersPart
+                  .split(',')
+                  .map((slug) => slug.trim().toLowerCase())
+                  .filter((slug): slug is LayerSlug => slug in LAYER_SLUGS)
+                  .map((slug) => LAYER_SLUGS[slug]);
+
+    const basemap = BASEMAPS.includes(basemapPart as Basemap) ? (basemapPart as Basemap) : 'osm';
+
+    return {
+        zoom: clamp(Math.round(zoom), 1, 19),
+        lat: clamp(lat, -MAX_LATITUDE, MAX_LATITUDE),
+        lon: wrapLongitude(lon),
+        layers,
+        basemap,
+    };
+}
+
+/** Builds the hash for a given view. Always starts with '#'. */
+export function formatMapHash(state: MapUrlState): string {
+    const active = state.layers ?? [];
+    const slugs = (Object.keys(LAYER_SLUGS) as LayerSlug[]).filter((slug) =>
+        active.includes(LAYER_SLUGS[slug])
+    );
+
+    return [
+        `#${clamp(Math.round(state.zoom), 1, 19)}`,
+        clamp(state.lat, -MAX_LATITUDE, MAX_LATITUDE).toFixed(COORD_PRECISION),
+        wrapLongitude(state.lon).toFixed(COORD_PRECISION),
+        slugs.join(','),
+        state.basemap,
+    ].join('/');
+}
+
+/** Turns the `visibleLayers` state object into the list of enabled keys. */
+export function enabledLayerKeys(visible: Record<string, boolean>): LayerKey[] {
+    return Object.values(LAYER_SLUGS).filter((key) => visible[key]);
+}

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,0 +1,48 @@
+/**
+ * site.ts
+ *
+ * Single source of truth for facts about the deployment that several places
+ * need to agree on: the canonical origin, the provider list, and how fresh the
+ * coverage data actually is.
+ */
+
+/**
+ * Canonical origin, used for absolute URLs in metadata, the sitemap and
+ * Open Graph tags. Vercel exposes the deployment host but not the production
+ * domain, so this is set explicitly rather than inferred.
+ */
+export const SITE_URL = 'https://streetradar.app';
+
+export const SITE_NAME = 'StreetRadar';
+
+export const SITE_DESCRIPTION =
+    'See where Street View imagery exists worldwide. Coverage from Google, Apple Look Around, ' +
+    'Bing Streetside, Yandex, Naver and Já 360 on a single map.';
+
+/**
+ * When the coverage data was last rebuilt, per provider.
+ *
+ * This is displayed to visitors. The pipeline has not run since September 2025,
+ * and a coverage map that silently presents year-old data as current is worse
+ * than one that says how old it is. Update these when a refresh lands.
+ */
+export const COVERAGE_UPDATED: Record<string, string> = {
+    apple: '2025-02',
+    ja: '2025-09',
+    naver: '2025-09',
+};
+
+/** The oldest of the per-provider dates — what the site as a whole can claim. */
+export function oldestCoverageDate(): string {
+    return Object.values(COVERAGE_UPDATED).sort()[0];
+}
+
+/** Renders a YYYY-MM string as "February 2025". */
+export function formatCoverageMonth(yearMonth: string): string {
+    const [year, month] = yearMonth.split('-').map(Number);
+    return new Date(Date.UTC(year, month - 1, 1)).toLocaleDateString('en-US', {
+        month: 'long',
+        year: 'numeric',
+        timeZone: 'UTC',
+    });
+}


### PR DESCRIPTION
Google sends this site no traffic at all — every search referral comes from
Bing. There is no penalty involved: with three indexable URLs, no sitemap and
no robots.txt of its own, there is almost nothing for a crawler to find. This
addresses that, and makes the map linkable for the first time.

## Permalinks

`/map` was one URL for the entire planet.

```
/map#12/48.85341/2.34878/apple,google/satellite
```

Zoom, centre, enabled layers and basemap, restored on load. The hash rather
than a query string because it is what every mapping site uses and updating it
never round-trips to the server. Writes use `replaceState`: panning generates a
continuous stream of view changes, and pushing each one would make the back
button walk through hundreds of intermediate positions instead of leaving the
page.

An absent layer section and an empty one differ on purpose — no section keeps
the defaults, an empty one means the sender turned every overlay off.

## Discoverability

- `sitemap.xml`, which returned 404 before
- `robots.txt` of our own, naming the sitemap. What was being served came from
  Cloudflare's managed default
- An Open Graph card, generated rather than static so the provider list and
  coverage date track the code. Every link rendered as bare text before, which
  for a visual product quietly killed sharing in exactly the communities most
  likely to care
- Canonical URL, Twitter card, `metadataBase`, and a description that finally
  mentions Naver and Já 360 — supported for a year without ever being said

## Honesty about the data

`src/lib/site.ts` carries a per-provider coverage date, shown on the share card.
The pipeline has not run since September 2025 and Apple's statistics stop in
February 2025. A coverage map presenting year-old data as current is worse than
one that says how old it is — and it is what makes starting the SEO clock now
defensible while the data refresh waits on a machine.

## First tests in this repo

The hash parsing has enough edge cases that shipping it unverified was not
reasonable, so this brings in vitest. Writing the 24 tests **caught three real
bugs in my own implementation**:

- `Number('')` is `0`, not `NaN`, so `#12//2` parsed as a valid point on the
  equator instead of being rejected
- the longitude wrap ran modulo arithmetic unconditionally and lost float
  precision, turning `-21.89541` into `-21.89540999999997` and breaking the
  round trip
- `540` degrees comes back as `-180` rather than `180`; both spell the
  antimeridian, and the test now records which is canonical

## Verified

`format:check`, `lint`, `typecheck`, `test` and a secret-free `build`, plus the
generated routes checked against a running production server: robots and
sitemap render, and the card returns a 1200×630 PNG.

## Not here

Per-country pages. They would present February 2025 statistics as fact, so they
wait for the refresh. Search Console and Bing Webmaster need your accounts; the
Cloudflare cache rule needs a token with `Cache Rules: Edit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)