### PR TITLE
Split mapContainer into hooks

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -50,7 +50,6 @@ const eslintConfig = [
             'src/components/charts/CountryBarChart.tsx',
             'src/components/charts/CoverageChart.tsx',
             'src/components/charts/TimelineChart.tsx',
-            'src/components/map/mapContainer.tsx',
             'src/components/map/statisticsPanel.tsx',
         ],
         rules: {

--- a/src/components/map/mapContainer.tsx
+++ b/src/components/map/mapContainer.tsx
@@ -17,13 +17,12 @@ import 'leaflet/dist/leaflet.css';
 import '@/styles/leafletStyles.css';
 import StreetViewLayer from '@/services/streetViewLayer';
 import PegcatControl from './pegcatControl';
-import { PanoramaService } from '../../services/panoramaService';
-import { StreetViewDetectionResult } from '@/services/streetViewDetectionCanvas';
 import PanoramaBubble from '@/components/map/panoramaBubble';
 import StatisticsPanel from '@/components/map/statisticsPanel';
 import ProviderWarning from '@/components/map/providerWarning';
 import { useProviderWarnings } from '@/hooks/useProviderWarnings';
 import { useMapUI } from '@/hooks/useMapUI';
+import { usePanoramaDetection } from '@/hooks/usePanoramaDetection';
 import Image from 'next/image';
 
 /**
@@ -77,22 +76,6 @@ export default function MapContainer({
     const [currentBasemap, setCurrentBasemap] = useState(initialUrlState?.basemap ?? 'osm');
     // References to the basemap layers
     const basemapLayersRef = useRef<{ [key: string]: L.TileLayer }>({});
-    // Information about the last click/drop
-    const [clickInfo, setClickInfo] = useState<{
-        position: L.LatLng | null;
-        type: 'click' | 'drop';
-        timestamp: number;
-    } | null>(null);
-    // Panorama detection results
-    const [detectionResults, setDetectionResults] = useState<StreetViewDetectionResult[]>([]);
-    // Detected position to display the bubble
-    const [detectedPosition, setDetectedPosition] = useState<L.LatLng | null>(null);
-    // State indicating if detection is in progress
-    const [isDetecting, setIsDetecting] = useState<boolean>(false);
-    // Pixel position for temporary bubbles
-    const [tempBubbleScreenPos, setTempBubbleScreenPos] = useState<{ x: number; y: number } | null>(
-        null
-    );
     // One-time notices for providers with known limitations. Four booleans
     // before — two per provider, kept in step by hand — and two now.
     const providerWarnings = useProviderWarnings();
@@ -106,6 +89,19 @@ export default function MapContainer({
         toggleStatisticsPanel,
         closeBasemapSelector,
     } = useMapUI();
+
+    // Click -> detection -> bubble, and the marker that tracks the map while it
+    // moves. Five pieces of state and three effects, none of them about layers.
+    const {
+        clickInfo,
+        detectionResults,
+        detectedPosition,
+        isDetecting,
+        markerScreenPos,
+        handleMapClick,
+        handlePegcatDrop,
+        close: closePanoramaBubble,
+    } = usePanoramaDetection({ map: mapInstance, visibleLayers });
 
     // Mirror the current view into the URL hash so a position can be shared.
     useMapUrlState({ map: mapInstance, visibleLayers, basemap: currentBasemap });
@@ -287,54 +283,6 @@ export default function MapContainer({
         };
     }, [mapInstance]);
 
-    // Effect to update temporary bubble positions
-    useEffect(() => {
-        if (!mapInstance || !clickInfo?.position) {
-            setTempBubbleScreenPos(null);
-            return;
-        }
-
-        const updateTempBubblePosition = () => {
-            try {
-                const point = mapInstance.latLngToContainerPoint(clickInfo.position!);
-                setTempBubbleScreenPos({ x: point.x, y: point.y });
-            } catch (error) {
-                console.error('Error during coordinate conversion:', error);
-                setTempBubbleScreenPos(null);
-            }
-        };
-
-        // Update initial position
-        updateTempBubblePosition();
-
-        // Listen to map movement events
-        const events = ['move', 'zoom', 'zoomstart', 'zoomend', 'movestart', 'moveend'];
-        events.forEach((event) => {
-            mapInstance.on(event as keyof L.LeafletEventHandlerFnMap, updateTempBubblePosition);
-        });
-
-        // Cleanup event listeners
-        return () => {
-            events.forEach((event) => {
-                mapInstance.off(
-                    event as keyof L.LeafletEventHandlerFnMap,
-                    updateTempBubblePosition
-                );
-            });
-        };
-    }, [mapInstance, clickInfo?.position]);
-
-    // Effect to make info bubble disappear after a delay
-    useEffect(() => {
-        if (!clickInfo) return;
-
-        const timer = setTimeout(() => {
-            setClickInfo(null);
-        }, 5000); // 5 seconds
-
-        return () => clearTimeout(timer);
-    }, [clickInfo]);
-
     // Function to toggle layer visibility
     const toggleLayer = (layer: keyof typeof visibleLayers) => {
         // Only when switching a layer on, and only the first time for that provider.
@@ -385,104 +333,6 @@ export default function MapContainer({
 
         // Close the selector after selection
         closeBasemapSelector();
-    };
-
-    /**
-     * Handles PegCat drop event on the map
-     */
-    const handlePegcatDrop = async (latlng: L.LatLng) => {
-        // Start detection
-        await detectPanoramas(latlng, 'drop');
-    };
-
-    /**
-     * Handles map click when zoom is sufficient
-     */
-    const handleMapClick = async (latlng: L.LatLng) => {
-        // If a popup is already open, close it instead of opening a new one
-        if (detectedPosition) {
-            closePanoramaBubble();
-            return;
-        }
-
-        // Start detection
-        await detectPanoramas(latlng, 'click');
-    };
-
-    /**
-     * Common function to detect panoramas
-     */
-    const detectPanoramas = async (latlng: L.LatLng, type: 'click' | 'drop') => {
-        if (!mapInstance) return;
-
-        // Show indication that detection is in progress
-        setClickInfo({
-            position: latlng,
-            type,
-            timestamp: Date.now(),
-        });
-
-        // Mark that we're detecting
-        setIsDetecting(true);
-
-        try {
-            // Get list of active providers
-            const activeProviders = Object.entries(visibleLayers)
-                .filter(([, isVisible]) => isVisible)
-                .map(([provider]) => {
-                    if (provider === 'jaStreetView') return 'ja';
-                    return provider
-                        .replace('StreetView', '')
-                        .replace('Streetside', '')
-                        .replace('Panoramas', '')
-                        .replace('LookAround', '')
-                        .toLowerCase();
-                });
-
-            // Detect available panoramas
-            const results = await PanoramaService.detectPanoramasAt(
-                mapInstance,
-                latlng,
-                activeProviders,
-                { method: 'canvas' }
-            );
-
-            // Store results
-            setDetectionResults(results);
-
-            // Find first available point to position the bubble
-            const availableResult = results.find(
-                (r: StreetViewDetectionResult) => r.available && r.closestPoint
-            );
-            if (availableResult && availableResult.closestPoint) {
-                setDetectedPosition(availableResult.closestPoint);
-            } else {
-                // If no point found, use click position
-                setDetectedPosition(latlng);
-            }
-
-            // Clear click info
-            setClickInfo(null);
-        } catch (error) {
-            console.error('Error during panorama detection:', error);
-
-            // In case of error, use click position
-            setDetectedPosition(latlng);
-            setDetectionResults([]);
-
-            // Clear click info
-            setClickInfo(null);
-        } finally {
-            setIsDetecting(false);
-        }
-    };
-
-    /**
-     * Closes the panorama bubble
-     */
-    const closePanoramaBubble = () => {
-        setDetectedPosition(null);
-        setDetectionResults([]);
     };
 
     return (
@@ -735,13 +585,13 @@ export default function MapContainer({
                 mapInstance &&
                 !isDetecting &&
                 !detectedPosition &&
-                tempBubbleScreenPos && (
+                markerScreenPos && (
                     <div
                         className="info-bubble"
                         style={{
                             position: 'absolute',
-                            left: tempBubbleScreenPos.x,
-                            top: tempBubbleScreenPos.y - 30,
+                            left: markerScreenPos.x,
+                            top: markerScreenPos.y - 30,
                             background: '#fefbf1',
                             padding: '8px 12px',
                             borderRadius: '6px',
@@ -777,56 +627,52 @@ export default function MapContainer({
                 )}
 
             {/* Indicator during detection */}
-            {isDetecting &&
-                clickInfo &&
-                clickInfo.position &&
-                mapInstance &&
-                tempBubbleScreenPos && (
+            {isDetecting && clickInfo && clickInfo.position && mapInstance && markerScreenPos && (
+                <div
+                    className="detecting-bubble"
+                    style={{
+                        position: 'absolute',
+                        left: markerScreenPos.x,
+                        top: markerScreenPos.y - 30,
+                        background: '#fefbf1',
+                        padding: '10px 15px',
+                        borderRadius: '6px',
+                        boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)',
+                        zIndex: 1000,
+                        transform: 'translate(-50%, -100%)',
+                        fontSize: '14px',
+                        fontFamily: 'var(--font-geist-sans, sans-serif)',
+                        color: 'var(--sr-text, #333)',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '8px',
+                        pointerEvents: 'auto',
+                    }}
+                >
                     <div
-                        className="detecting-bubble"
+                        style={{
+                            width: '16px',
+                            height: '16px',
+                            borderRadius: '50%',
+                            border: '2px solid var(--sr-primary, #9b4434)',
+                            borderBottomColor: 'transparent',
+                            animation: 'spin 1s linear infinite',
+                        }}
+                    ></div>
+                    <div>Searching for panoramas...</div>
+                    <div
                         style={{
                             position: 'absolute',
-                            left: tempBubbleScreenPos.x,
-                            top: tempBubbleScreenPos.y - 30,
-                            background: '#fefbf1',
-                            padding: '10px 15px',
-                            borderRadius: '6px',
-                            boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)',
-                            zIndex: 1000,
-                            transform: 'translate(-50%, -100%)',
-                            fontSize: '14px',
-                            fontFamily: 'var(--font-geist-sans, sans-serif)',
-                            color: 'var(--sr-text, #333)',
-                            display: 'flex',
-                            alignItems: 'center',
-                            gap: '8px',
-                            pointerEvents: 'auto',
+                            bottom: '-8px',
+                            left: '50%',
+                            marginLeft: '-8px',
+                            borderLeft: '8px solid transparent',
+                            borderRight: '8px solid transparent',
+                            borderTop: '8px solid #fefbf1',
                         }}
-                    >
-                        <div
-                            style={{
-                                width: '16px',
-                                height: '16px',
-                                borderRadius: '50%',
-                                border: '2px solid var(--sr-primary, #9b4434)',
-                                borderBottomColor: 'transparent',
-                                animation: 'spin 1s linear infinite',
-                            }}
-                        ></div>
-                        <div>Searching for panoramas...</div>
-                        <div
-                            style={{
-                                position: 'absolute',
-                                bottom: '-8px',
-                                left: '50%',
-                                marginLeft: '-8px',
-                                borderLeft: '8px solid transparent',
-                                borderRight: '8px solid transparent',
-                                borderTop: '8px solid #fefbf1',
-                            }}
-                        ></div>
-                    </div>
-                )}
+                    ></div>
+                </div>
+            )}
 
             {/* Panorama bubble with results */}
             {detectedPosition && !isDetecting && mapInstance && (

--- a/src/components/map/mapContainer.tsx
+++ b/src/components/map/mapContainer.tsx
@@ -21,6 +21,9 @@ import { PanoramaService } from '../../services/panoramaService';
 import { StreetViewDetectionResult } from '@/services/streetViewDetectionCanvas';
 import PanoramaBubble from '@/components/map/panoramaBubble';
 import StatisticsPanel from '@/components/map/statisticsPanel';
+import ProviderWarning from '@/components/map/providerWarning';
+import { useProviderWarnings } from '@/hooks/useProviderWarnings';
+import { useMapUI } from '@/hooks/useMapUI';
 import Image from 'next/image';
 
 /**
@@ -70,12 +73,8 @@ export default function MapContainer({
         }
         return fromUrl;
     });
-    // Control panel collapsed state
-    const [isPanelCollapsed, setIsPanelCollapsed] = useState(false);
     // Basemap selection
     const [currentBasemap, setCurrentBasemap] = useState(initialUrlState?.basemap ?? 'osm');
-    // Basemap selector open state
-    const [isBasemapSelectorOpen, setIsBasemapSelectorOpen] = useState(false);
     // References to the basemap layers
     const basemapLayersRef = useRef<{ [key: string]: L.TileLayer }>({});
     // Information about the last click/drop
@@ -94,16 +93,19 @@ export default function MapContainer({
     const [tempBubbleScreenPos, setTempBubbleScreenPos] = useState<{ x: number; y: number } | null>(
         null
     );
-    // State for Yandex warning popup
-    const [showYandexWarning, setShowYandexWarning] = useState<boolean>(false);
-    // Flag to know if Yandex warning has already been shown
-    const [yandexWarningShown, setYandexWarningShown] = useState<boolean>(false);
-    // State for Apple warning popup
-    const [showAppleWarning, setShowAppleWarning] = useState<boolean>(false);
-    // Flag to know if Apple warning has already been shown
-    const [appleWarningShown, setAppleWarningShown] = useState<boolean>(false);
-    // Statistics panel open state
-    const [isStatisticsPanelOpen, setIsStatisticsPanelOpen] = useState<boolean>(false);
+    // One-time notices for providers with known limitations. Four booleans
+    // before — two per provider, kept in step by hand — and two now.
+    const providerWarnings = useProviderWarnings();
+    // Open/closed state for the panel, basemap picker and statistics drawer.
+    const {
+        isPanelCollapsed,
+        isBasemapSelectorOpen,
+        isStatisticsPanelOpen,
+        togglePanel,
+        toggleBasemapSelector,
+        toggleStatisticsPanel,
+        closeBasemapSelector,
+    } = useMapUI();
 
     // Mirror the current view into the URL hash so a position can be shared.
     useMapUrlState({ map: mapInstance, visibleLayers, basemap: currentBasemap });
@@ -335,16 +337,9 @@ export default function MapContainer({
 
     // Function to toggle layer visibility
     const toggleLayer = (layer: keyof typeof visibleLayers) => {
-        // If activating Yandex and it wasn't already activated AND the warning has never been shown
-        if (layer === 'yandexPanoramas' && !visibleLayers.yandexPanoramas && !yandexWarningShown) {
-            setShowYandexWarning(true);
-            setYandexWarningShown(true); // Mark as shown to never show it again
-        }
-
-        // If activating Apple and it wasn't already activated AND the warning has never been shown
-        if (layer === 'appleLookAround' && !visibleLayers.appleLookAround && !appleWarningShown) {
-            setShowAppleWarning(true);
-            setAppleWarningShown(true); // Mark as shown to never show it again
+        // Only when switching a layer on, and only the first time for that provider.
+        if (!visibleLayers[layer]) {
+            providerWarnings.warnOnce(layer);
         }
 
         setVisibleLayers((prev) => ({
@@ -360,11 +355,6 @@ export default function MapContainer({
     ) => {
         e.stopPropagation(); // Stop propagation to prevent double toggle
         toggleLayer(layer);
-    };
-
-    // Toggle panel collapsed state
-    const togglePanel = () => {
-        setIsPanelCollapsed(!isPanelCollapsed);
     };
 
     // Function to change basemap
@@ -394,17 +384,7 @@ export default function MapContainer({
         setCurrentBasemap(basemap);
 
         // Close the selector after selection
-        setIsBasemapSelectorOpen(false);
-    };
-
-    // Toggle basemap selector
-    const toggleBasemapSelector = () => {
-        setIsBasemapSelectorOpen(!isBasemapSelectorOpen);
-    };
-
-    // Toggle statistics panel
-    const toggleStatisticsPanel = () => {
-        setIsStatisticsPanelOpen(!isStatisticsPanelOpen);
+        closeBasemapSelector();
     };
 
     /**
@@ -503,20 +483,6 @@ export default function MapContainer({
     const closePanoramaBubble = () => {
         setDetectedPosition(null);
         setDetectionResults([]);
-    };
-
-    /**
-     * Closes the Yandex warning popup
-     */
-    const closeYandexWarning = () => {
-        setShowYandexWarning(false);
-    };
-
-    /**
-     * Closes the Apple warning popup
-     */
-    const closeAppleWarning = () => {
-        setShowAppleWarning(false);
     };
 
     return (
@@ -872,174 +838,12 @@ export default function MapContainer({
                 />
             )}
 
-            {/* Yandex warning popup */}
-            {showYandexWarning && (
-                <div
-                    style={{
-                        position: 'fixed',
-                        top: 0,
-                        left: 0,
-                        right: 0,
-                        bottom: 0,
-                        backgroundColor: 'rgba(0, 0, 0, 0.5)',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        zIndex: 2000,
-                        animation: 'fadeIn 0.3s ease',
-                    }}
-                    onClick={closeYandexWarning}
-                >
-                    <div
-                        style={{
-                            background: '#fefbf1',
-                            padding: '24px',
-                            borderRadius: '12px',
-                            boxShadow: '0 8px 32px rgba(0, 0, 0, 0.2)',
-                            maxWidth: '400px',
-                            width: '90%',
-                            fontFamily: 'var(--font-geist-sans, sans-serif)',
-                            color: 'var(--sr-text, #333)',
-                            textAlign: 'center',
-                            transform: 'scale(1)',
-                            animation: 'popIn 0.3s cubic-bezier(0.34, 1.56, 0.64, 1)',
-                        }}
-                        onClick={(e) => e.stopPropagation()}
-                    >
-                        <div style={{ fontSize: '48px', marginBottom: '16px' }}>⚠️</div>
-                        <h3
-                            style={{
-                                margin: '0 0 16px 0',
-                                fontSize: '20px',
-                                fontWeight: '600',
-                                color: 'var(--sr-primary, #9b4434)',
-                            }}
-                        >
-                            Yandex Panoramas - Alpha Feature
-                        </h3>
-                        <p
-                            style={{
-                                margin: '0 0 20px 0',
-                                fontSize: '16px',
-                                lineHeight: '1.5',
-                                color: 'var(--sr-text-light, #666)',
-                            }}
-                        >
-                            Yandex Panoramas support is currently in alpha testing. Coverage
-                            detection and panorama links may not work as expected.
-                        </p>
-                        <button
-                            onClick={closeYandexWarning}
-                            style={{
-                                background: 'var(--sr-primary, #9b4434)',
-                                color: 'white',
-                                border: 'none',
-                                padding: '10px 20px',
-                                borderRadius: '8px',
-                                cursor: 'pointer',
-                                fontSize: '14px',
-                                fontWeight: '500',
-                                transition: 'all 0.2s ease',
-                            }}
-                            onMouseOver={(e) => {
-                                e.currentTarget.style.background = '#7a3429';
-                            }}
-                            onMouseOut={(e) => {
-                                e.currentTarget.style.background = 'var(--sr-primary, #9b4434)';
-                            }}
-                        >
-                            I understand
-                        </button>
-                    </div>
-                </div>
-            )}
-
-            {/* Apple warning popup */}
-            {showAppleWarning && (
-                <div
-                    style={{
-                        position: 'fixed',
-                        top: 0,
-                        left: 0,
-                        right: 0,
-                        bottom: 0,
-                        backgroundColor: 'rgba(0, 0, 0, 0.5)',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        zIndex: 2000,
-                        animation: 'fadeIn 0.3s ease',
-                    }}
-                    onClick={closeAppleWarning}
-                >
-                    <div
-                        style={{
-                            background: '#fefbf1',
-                            padding: '24px',
-                            borderRadius: '12px',
-                            boxShadow: '0 8px 32px rgba(0, 0, 0, 0.2)',
-                            maxWidth: '420px',
-                            width: '90%',
-                            fontFamily: 'var(--font-geist-sans, sans-serif)',
-                            color: 'var(--sr-text, #333)',
-                            textAlign: 'center',
-                            transform: 'scale(1)',
-                            animation: 'popIn 0.3s cubic-bezier(0.34, 1.56, 0.64, 1)',
-                        }}
-                        onClick={(e) => e.stopPropagation()}
-                    >
-                        <div style={{ fontSize: '48px', marginBottom: '16px' }}>⚠️</div>
-                        <h3
-                            style={{
-                                margin: '0 0 16px 0',
-                                fontSize: '20px',
-                                fontWeight: '600',
-                                color: 'var(--sr-primary, #9b4434)',
-                            }}
-                        >
-                            Apple Look Around - Beta Feature
-                        </h3>
-                        <div
-                            style={{
-                                margin: '0 0 20px 0',
-                                fontSize: '16px',
-                                lineHeight: '1.5',
-                                color: 'var(--sr-text-light, #666)',
-                                textAlign: 'left',
-                            }}
-                        >
-                            <p style={{ margin: '0 0 12px 0' }}>
-                                Apple Look Around support is currently in beta. Known issues:
-                            </p>
-                            <ul style={{ margin: '0', paddingLeft: '20px' }}>
-                                <li>Maximum zoom level: 16</li>
-                                <li>Map matching contains errors for Canada, Spain, and Italy</li>
-                            </ul>
-                        </div>
-                        <button
-                            onClick={closeAppleWarning}
-                            style={{
-                                background: 'var(--sr-primary, #9b4434)',
-                                color: 'white',
-                                border: 'none',
-                                padding: '10px 20px',
-                                borderRadius: '8px',
-                                cursor: 'pointer',
-                                fontSize: '14px',
-                                fontWeight: '500',
-                                transition: 'all 0.2s ease',
-                            }}
-                            onMouseOver={(e) => {
-                                e.currentTarget.style.background = '#7a3429';
-                            }}
-                            onMouseOut={(e) => {
-                                e.currentTarget.style.background = 'var(--sr-primary, #9b4434)';
-                            }}
-                        >
-                            I understand
-                        </button>
-                    </div>
-                </div>
+            {/* One-time notice for providers with known limitations. */}
+            {providerWarnings.active && (
+                <ProviderWarning
+                    provider={providerWarnings.active}
+                    onDismiss={providerWarnings.dismiss}
+                />
             )}
 
             {/* Loading animation styles */}

--- a/src/components/map/providerWarning.tsx
+++ b/src/components/map/providerWarning.tsx
@@ -1,0 +1,126 @@
+/**
+ * providerWarning.tsx
+ *
+ * The one-time notice shown when a provider with known limitations is enabled.
+ *
+ * The Yandex and Apple versions of this were two nearly identical blocks in
+ * mapContainer — 155 lines whose only real differences were the title, the body
+ * and a 20px width. Adding a third provider meant copying it a third time.
+ */
+
+'use client';
+
+import { useEffect } from 'react';
+import { PROVIDER_WARNINGS, type WarnedProvider } from '@/hooks/useProviderWarnings';
+
+interface ProviderWarningProps {
+    provider: WarnedProvider;
+    onDismiss: () => void;
+}
+
+export default function ProviderWarning({ provider, onDismiss }: ProviderWarningProps) {
+    const warning = PROVIDER_WARNINGS[provider];
+    const caveats = 'caveats' in warning ? warning.caveats : undefined;
+
+    // Escape closes the dialog. The previous version could only be dismissed by
+    // clicking, which left keyboard users stuck behind a modal overlay.
+    useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') onDismiss();
+        };
+        window.addEventListener('keydown', onKeyDown);
+        return () => window.removeEventListener('keydown', onKeyDown);
+    }, [onDismiss]);
+
+    return (
+        <div
+            style={{
+                position: 'fixed',
+                inset: 0,
+                backgroundColor: 'rgba(0, 0, 0, 0.5)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                zIndex: 2000,
+                animation: 'fadeIn 0.3s ease',
+            }}
+            onClick={onDismiss}
+        >
+            <div
+                role="alertdialog"
+                aria-modal="true"
+                aria-labelledby="provider-warning-title"
+                style={{
+                    background: '#fefbf1',
+                    padding: '24px',
+                    borderRadius: '12px',
+                    boxShadow: '0 8px 32px rgba(0, 0, 0, 0.2)',
+                    maxWidth: '420px',
+                    width: '90%',
+                    fontFamily: 'var(--font-geist-sans, sans-serif)',
+                    color: 'var(--sr-text, #333)',
+                    textAlign: 'center',
+                    animation: 'popIn 0.3s cubic-bezier(0.34, 1.56, 0.64, 1)',
+                }}
+                onClick={(event) => event.stopPropagation()}
+            >
+                <div style={{ fontSize: '48px', marginBottom: '16px' }} aria-hidden="true">
+                    ⚠️
+                </div>
+                <h3
+                    id="provider-warning-title"
+                    style={{
+                        margin: '0 0 16px 0',
+                        fontSize: '20px',
+                        fontWeight: 600,
+                        color: 'var(--sr-primary, #9b4434)',
+                    }}
+                >
+                    {warning.title}
+                </h3>
+                <div
+                    style={{
+                        margin: '0 0 20px 0',
+                        fontSize: '16px',
+                        lineHeight: 1.5,
+                        color: 'var(--sr-text-light, #666)',
+                        textAlign: caveats ? 'left' : 'center',
+                    }}
+                >
+                    <p style={{ margin: caveats ? '0 0 12px 0' : 0 }}>{warning.body}</p>
+                    {caveats && (
+                        <ul style={{ margin: 0, paddingLeft: '20px' }}>
+                            {caveats.map((caveat) => (
+                                <li key={caveat}>{caveat}</li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
+                <button
+                    type="button"
+                    autoFocus
+                    onClick={onDismiss}
+                    style={{
+                        background: 'var(--sr-primary, #9b4434)',
+                        color: 'white',
+                        border: 'none',
+                        padding: '10px 20px',
+                        borderRadius: '8px',
+                        cursor: 'pointer',
+                        fontSize: '14px',
+                        fontWeight: 500,
+                        transition: 'all 0.2s ease',
+                    }}
+                    onMouseOver={(event) => {
+                        event.currentTarget.style.background = '#7a3429';
+                    }}
+                    onMouseOut={(event) => {
+                        event.currentTarget.style.background = 'var(--sr-primary, #9b4434)';
+                    }}
+                >
+                    I understand
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/hooks/useMapUI.ts
+++ b/src/hooks/useMapUI.ts
@@ -1,0 +1,39 @@
+/**
+ * useMapUI.ts
+ *
+ * Open/closed state for the map's chrome: the layer panel, the basemap picker
+ * and the statistics drawer.
+ *
+ * Three booleans and three near-identical togglers, all unrelated to what the
+ * map is actually showing. Grouping them keeps mapContainer's state list about
+ * the map rather than about its furniture.
+ */
+
+'use client';
+
+import { useCallback, useState } from 'react';
+
+export function useMapUI() {
+    const [isPanelCollapsed, setPanelCollapsed] = useState(false);
+    const [isBasemapSelectorOpen, setBasemapSelectorOpen] = useState(false);
+    const [isStatisticsPanelOpen, setStatisticsPanelOpen] = useState(false);
+
+    const togglePanel = useCallback(() => setPanelCollapsed((open) => !open), []);
+
+    const toggleBasemapSelector = useCallback(() => setBasemapSelectorOpen((open) => !open), []);
+
+    const toggleStatisticsPanel = useCallback(() => setStatisticsPanelOpen((open) => !open), []);
+
+    /** Called after picking a basemap, which closes the picker. */
+    const closeBasemapSelector = useCallback(() => setBasemapSelectorOpen(false), []);
+
+    return {
+        isPanelCollapsed,
+        isBasemapSelectorOpen,
+        isStatisticsPanelOpen,
+        togglePanel,
+        toggleBasemapSelector,
+        toggleStatisticsPanel,
+        closeBasemapSelector,
+    };
+}

--- a/src/hooks/usePanoramaDetection.ts
+++ b/src/hooks/usePanoramaDetection.ts
@@ -1,0 +1,172 @@
+/**
+ * usePanoramaDetection.ts
+ *
+ * Everything that happens between a click on the map and a panorama bubble:
+ * the transient "clicked here" marker, the detection request, its results, and
+ * the screen position the bubble is pinned to while the map moves.
+ *
+ * Five pieces of state and three effects, all of which lived in mapContainer
+ * next to layer toggles and panel visibility. None of them are related to those.
+ */
+
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type L from 'leaflet';
+import { PanoramaService } from '@/services/panoramaService';
+import type { StreetViewDetectionResult } from '@/services/streetViewDetectionCanvas';
+
+/** How long the transient click marker stays before fading out. */
+const CLICK_MARKER_TIMEOUT_MS = 5000;
+
+/** Leaflet events after which the bubble has to be re-anchored. */
+const MAP_MOVE_EVENTS = ['move', 'zoom', 'zoomstart', 'zoomend', 'movestart', 'moveend'] as const;
+
+export interface ClickInfo {
+    position: L.LatLng | null;
+    type: 'click' | 'drop';
+    timestamp: number;
+}
+
+/**
+ * Turns the layer state keys into the provider ids PanoramaService expects:
+ * googleStreetView -> google, appleLookAround -> apple, jaStreetView -> ja.
+ */
+export function activeProviderIds(visibleLayers: Record<string, boolean>): string[] {
+    return Object.entries(visibleLayers)
+        .filter(([, isVisible]) => isVisible)
+        .map(([layer]) => {
+            if (layer === 'jaStreetView') return 'ja';
+            return layer
+                .replace('StreetView', '')
+                .replace('Streetside', '')
+                .replace('Panoramas', '')
+                .replace('LookAround', '')
+                .toLowerCase();
+        });
+}
+
+interface Options {
+    map: L.Map | null;
+    visibleLayers: Record<string, boolean>;
+}
+
+export function usePanoramaDetection({ map, visibleLayers }: Options) {
+    const [clickInfo, setClickInfo] = useState<ClickInfo | null>(null);
+    const [detectionResults, setDetectionResults] = useState<StreetViewDetectionResult[]>([]);
+    const [detectedPosition, setDetectedPosition] = useState<L.LatLng | null>(null);
+    const [isDetecting, setIsDetecting] = useState(false);
+    // Bumped on every map move so the derived pixel position recomputes.
+    const [moveTick, setMoveTick] = useState(0);
+
+    // Keep the transient marker pinned to its geographic point while the map
+    // moves under it.
+    //
+    // The effect only subscribes and bumps a counter; the pixel position is
+    // derived during render. Projecting inside the effect and calling setState
+    // there would run a second render pass before every paint, which is what
+    // react-hooks/set-state-in-effect is about — and re-projecting is cheap
+    // enough that deriving it is simply the better shape.
+    useEffect(() => {
+        if (!map || !clickInfo?.position) return;
+
+        const onMapMoved = () => setMoveTick((tick) => tick + 1);
+        MAP_MOVE_EVENTS.forEach((event) => map.on(event, onMapMoved));
+
+        return () => {
+            MAP_MOVE_EVENTS.forEach((event) => map.off(event, onMapMoved));
+        };
+    }, [map, clickInfo?.position]);
+
+    const markerScreenPos = useMemo(() => {
+        const position = clickInfo?.position;
+        if (!map || !position) return null;
+
+        try {
+            const point = map.latLngToContainerPoint(position);
+            return { x: point.x, y: point.y };
+        } catch (error) {
+            console.error('Error during coordinate conversion:', error);
+            return null;
+        }
+        // moveTick is the dependency that matters: it is what changes when the
+        // map pans or zooms under a fixed geographic point.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [map, clickInfo?.position, moveTick]);
+
+    // The marker is transient: it disappears on its own if detection has not
+    // replaced it by then.
+    useEffect(() => {
+        if (!clickInfo) return;
+        const timer = setTimeout(() => setClickInfo(null), CLICK_MARKER_TIMEOUT_MS);
+        return () => clearTimeout(timer);
+    }, [clickInfo]);
+
+    const close = useCallback(() => {
+        setDetectedPosition(null);
+        setDetectionResults([]);
+    }, []);
+
+    const detect = useCallback(
+        async (latlng: L.LatLng, type: 'click' | 'drop') => {
+            if (!map) return;
+
+            setClickInfo({ position: latlng, type, timestamp: Date.now() });
+            setIsDetecting(true);
+
+            try {
+                const results = await PanoramaService.detectPanoramasAt(
+                    map,
+                    latlng,
+                    activeProviderIds(visibleLayers),
+                    { method: 'canvas' }
+                );
+
+                setDetectionResults(results);
+
+                // Anchor the bubble to the nearest actual panorama when there is
+                // one, so it does not float over empty road.
+                const found = results.find(
+                    (result: StreetViewDetectionResult) => result.available && result.closestPoint
+                );
+                setDetectedPosition(found?.closestPoint ?? latlng);
+            } catch (error) {
+                console.error('Error during panorama detection:', error);
+                setDetectedPosition(latlng);
+                setDetectionResults([]);
+            } finally {
+                setClickInfo(null);
+                setIsDetecting(false);
+            }
+        },
+        [map, visibleLayers]
+    );
+
+    /** A click on an open bubble closes it rather than starting a new search. */
+    const handleMapClick = useCallback(
+        async (latlng: L.LatLng) => {
+            if (detectedPosition) {
+                close();
+                return;
+            }
+            await detect(latlng, 'click');
+        },
+        [detectedPosition, close, detect]
+    );
+
+    const handlePegcatDrop = useCallback(
+        async (latlng: L.LatLng) => detect(latlng, 'drop'),
+        [detect]
+    );
+
+    return {
+        clickInfo,
+        detectionResults,
+        detectedPosition,
+        isDetecting,
+        markerScreenPos,
+        handleMapClick,
+        handlePegcatDrop,
+        close,
+    };
+}

--- a/src/hooks/useProviderWarnings.ts
+++ b/src/hooks/useProviderWarnings.ts
@@ -1,0 +1,63 @@
+/**
+ * useProviderWarnings.ts
+ *
+ * Tracks the one-time notice shown when a provider whose support is not fully
+ * reliable is enabled for the first time.
+ *
+ * This replaces four booleans in mapContainer — showYandexWarning,
+ * yandexWarningShown, showAppleWarning, appleWarningShown — which cost two more
+ * for every provider added and had to be kept in step by hand. A set of
+ * already-seen providers plus the one currently on screen says the same thing
+ * and does not grow.
+ */
+
+'use client';
+
+import { useCallback, useState } from 'react';
+
+/** Providers that carry a caveat worth showing once. */
+export const PROVIDER_WARNINGS = {
+    yandexPanoramas: {
+        title: 'Yandex Panoramas — Alpha Feature',
+        body: 'Yandex Panoramas support is currently in alpha testing. Coverage detection and panorama links may not work as expected.',
+    },
+    appleLookAround: {
+        title: 'Apple Look Around — Beta Feature',
+        body: 'Apple Look Around support is currently in beta. Known issues:',
+        caveats: [
+            'Maximum zoom level: 16',
+            'Map matching contains errors for Canada, Spain, and Italy',
+        ],
+    },
+} as const;
+
+export type WarnedProvider = keyof typeof PROVIDER_WARNINGS;
+
+export function isWarnedProvider(layer: string): layer is WarnedProvider {
+    return layer in PROVIDER_WARNINGS;
+}
+
+export function useProviderWarnings() {
+    /** The notice on screen right now, if any. */
+    const [active, setActive] = useState<WarnedProvider | null>(null);
+
+    /** Providers already warned about. Shown once per session, as before. */
+    const [seen, setSeen] = useState<ReadonlySet<WarnedProvider>>(() => new Set());
+
+    /**
+     * Show the notice for a provider unless it has already been shown.
+     * Safe to call for any layer — non-warned ones are ignored.
+     */
+    const warnOnce = useCallback(
+        (layer: string) => {
+            if (!isWarnedProvider(layer) || seen.has(layer)) return;
+            setActive(layer);
+            setSeen((previous) => new Set(previous).add(layer));
+        },
+        [seen]
+    );
+
+    const dismiss = useCallback(() => setActive(null), []);
+
+    return { active, warnOnce, dismiss };
+}


### PR DESCRIPTION
```
mapContainer.tsx   1078 lines -> 728
useState            16 -> 4
useEffect            5 -> 2
```

Three clusters came out, none of which had anything to do with each other or
with the map itself.

## Provider warnings — four booleans to two

`showYandexWarning`, `yandexWarningShown`, `showAppleWarning`,
`appleWarningShown` held one question between them: which providers have been
warned about, and which notice is on screen. Two booleans per provider, kept in
step by hand, and a third provider would have cost two more.

The two modals were **169 lines of JSX** whose only differences were the title,
the body and 20px of width. They are now one `ProviderWarning` component and a
seven-line call site. Adding a provider is an entry in `PROVIDER_WARNINGS`.

Two fixes fell out of the move: the dialog can be dismissed with **Escape**,
which it could not before — a keyboard user was trapped behind the overlay —
and it carries `role="alertdialog"` with a labelled title.

## Panorama detection

The transient click marker, the detection request, its results, the bubble
anchor, and the pixel position the marker tracks while the map moves under it.

The provider-id mapping — `googleStreetView` to `google` via a chain of string
replaces — was buried inline in the detection call. It is now a named exported
function, which is the sort of thing that should be testable.

**The marker position no longer setStates from inside an effect.** The effect
subscribes to map moves and bumps a counter; the pixel position is derived
during render with `useMemo`. The old shape projected and setState in the effect
body, running a second render pass before every paint — exactly what React
19.2's `react-hooks/set-state-in-effect` flags. Writing new code straight onto
the suppression list would have been the wrong answer.

That also lets **mapContainer come off that list entirely**. Five files left,
all charts and the statistics panel, all the same pattern.

## UI state

Three open/closed booleans and three near-identical togglers, none of which say
anything about what the map shows.

## Verification, and its limit

`format:check`, `lint`, `typecheck`, `test` and a secret-free `build` all pass.

Behaviour is preserved by construction — the JSX is untouched apart from the two
consolidated modals, and the logic moved verbatim apart from the position
derivation. But **none of this has been clicked through in a browser.** The
preview on this PR is the place to check three flows: clicking the map, dropping
the pegcat, and enabling Yandex or Apple for the first time.

## Left in Phase 3

Tailwind + shadcn, and the five remaining suppressed lint entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)