### PR TITLE
Make /map and /analytics indexable, and stop telling Google to ignore them

### DIFF
--- a/docs/STRATEGY-FINDINGS.md
+++ b/docs/STRATEGY-FINDINGS.md
@@ -15,17 +15,17 @@ Every recommendation below is re-scored against that, not against growth.
 
 ## Decision A — Is there a business here? No. Unanimous across five agents.
 
-| Route | Finding | Source |
-|---|---|---|
-| Paid API / dataset sale | No identified buyer. No street-level coverage dataset is sold anywhere, by anyone, at any price. 17 months live, zero inbound commercial enquiry. | SaaS strategist |
-| €1,000 MRR | Needs ~20,000 visitors/month — **40× current traffic** | SaaS strategist |
-| Display ads | **€0.50–1.00/month.** Raptive floor 25,000 pv/mo; Mediavine Journey floor 1,000 sessions (site is at ~half); AdSense payout threshold €70 would take years | Ad monetization |
-| Affiliate | **GeoGuessr has no affiliate program at all** (`/affiliate` 404, `/partners` 404, zero ToS mentions). Referral pays subscription credit and requires you to already be a paying subscriber. Creator program is cosmetics-only, gated at 1,000 followers. Realistic: **€0–5/month** | Affiliate research |
-| Advertiser demand | **CPC $0.00** across essentially the entire keyword cluster | SEO strategist |
-| Ad-blocking | ~**50%** on this specific audience (Plausible measured 58.67% on HN/Reddit traffic; 68.2% desktop; Linux 82.3%). Acceptable Ads would recover half of that — taking €0.65/mo to €1.00/mo | Ad-block research |
+| Route                   | Finding                                                                                                                                                                                                                                                                            | Source             |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| Paid API / dataset sale | No identified buyer. No street-level coverage dataset is sold anywhere, by anyone, at any price. 17 months live, zero inbound commercial enquiry.                                                                                                                                  | SaaS strategist    |
+| €1,000 MRR              | Needs ~20,000 visitors/month — **40× current traffic**                                                                                                                                                                                                                             | SaaS strategist    |
+| Display ads             | **€0.50–1.00/month.** Raptive floor 25,000 pv/mo; Mediavine Journey floor 1,000 sessions (site is at ~half); AdSense payout threshold €70 would take years                                                                                                                         | Ad monetization    |
+| Affiliate               | **GeoGuessr has no affiliate program at all** (`/affiliate` 404, `/partners` 404, zero ToS mentions). Referral pays subscription credit and requires you to already be a paying subscriber. Creator program is cosmetics-only, gated at 1,000 followers. Realistic: **€0–5/month** | Affiliate research |
+| Advertiser demand       | **CPC $0.00** across essentially the entire keyword cluster                                                                                                                                                                                                                        | SEO strategist     |
+| Ad-blocking             | ~**50%** on this specific audience (Plausible measured 58.67% on HN/Reddit traffic; 68.2% desktop; Linux 82.3%). Acceptable Ads would recover half of that — taking €0.65/mo to €1.00/mo                                                                                           | Ad-block research  |
 
 Structural note worth keeping: the entire GeoGuessr-alternative ecosystem competes
-*on being free* (Plonk It explicitly: "we don't use ads or charge for any of our
+_on being free_ (Plonk It explicitly: "we don't use ads or charge for any of our
 features"). A category whose value proposition is not-paying has nothing to pay an
 affiliate out of. Not a temporary gap — the category's economics.
 
@@ -35,7 +35,7 @@ $500/month against $500/month of infrastructure. **Net personal income $0.**
 Donations asymptote to costs, never above them.
 
 → **Decision: closed.** Matches the owner's own position. The research's value here
-is confirming that monetising would be both worthless *and* actively harmful —
+is confirming that monetising would be both worthless _and_ actively harmful —
 see Decision F.
 
 ---
@@ -58,11 +58,11 @@ the 0% Google / 18.5% Bing split that was measured.
 
 Second cause, equally decisive — measured visible word counts from raw HTML:
 
-| URL | Visible words | H1 | JSON-LD |
-|---|---|---|---|
-| `/` | ~90 | brand only, zero keywords | 0 |
-| `/map` | **6** — literally `Loading map...` | **none** | 0 |
-| `/analytics` | 109, mostly nav chrome + "Coming Soon" | present | 0 |
+| URL          | Visible words                          | H1                        | JSON-LD |
+| ------------ | -------------------------------------- | ------------------------- | ------- |
+| `/`          | ~90                                    | brand only, zero keywords | 0       |
+| `/map`       | **6** — literally `Loading map...`     | **none**                  | 0       |
+| `/analytics` | 109, mostly nav chrome + "Coming Soon" | present                   | 0       |
 
 ~166 words site-wide. Every chart is `'use client'` fetching JSON at runtime, so the
 entire data asset is invisible in the HTML. Bot blocking was ruled out by test:
@@ -73,8 +73,10 @@ Also flagged: `/map#12/48.85/2.34/apple,google/osm` permalinks have **zero SEO
 value** — Googlebot discards everything after `#`. Great share links, zero
 indexable URLs. And `www.streetradar.app` returns SSL error 526.
 
-→ **Status: fix pushed on `fix/canonical-urls`, CI green, NOT MERGED.** ~1 day of
-work for the rest. Highest ROI item in the entire corpus.
+→ **Status: fixed in PR #44**, along with 281 server-rendered words and an H1 on
+`/map`, and JSON-LD on all three pages. Highest ROI item in the entire corpus.
+Still outstanding from this section: the `www` SSL 526, which is a Cloudflare/Vercel
+domain setting rather than a code change.
 
 ---
 
@@ -84,7 +86,7 @@ work for the rest. Highest ROI item in the entire corpus.
 
 Google autocomplete swept across 40 countries for `"does {country} have street
 view"`. **Only 13 autocomplete** — and they are almost exclusively countries where
-coverage is *absent, restricted or surprising*: China, Russia, Germany, Japan,
+coverage is _absent, restricted or surprising_: China, Russia, Germany, Japan,
 Israel, Taiwan, Hong Kong, Turkey, Mexico, Iceland, Switzerland, Poland, UK.
 Volume confirms: china 1,900 · africa 1,300 · india 1,000 · germany 1,000.
 
@@ -111,7 +113,7 @@ Three caveats: the topic is **declining ~30%/yr** (13,389 in 2025 → 8,500 in 2
 CPC is $0.00; **Yandex interest collapsed 94%** (25,118 → 1,617) while Apple more
 than doubled.
 
-**Competitive gap is genuinely open.** Per-country *multi-provider* coverage pages do
+**Competitive gap is genuinely open.** Per-country _multi-provider_ coverage pages do
 not exist anywhere. geomastr has 101 country pages but coverage is one page and
 `/country/japan/` contains the phrase "Street View" **zero times**. geometas country
 pages are 214 words, no tables, no schema. Wikipedia is provider-siloed by design and
@@ -142,11 +144,11 @@ citation is a real traffic channel.
 Verified: all three raster coverage endpoints already in `src/services/
 streetViewService.ts` are publicly samplable and cleanly discriminate coverage at z10.
 
-| | Paris | Beijing | Moscow | Seattle |
-|---|---|---|---|---|
-| Google | 37,603 B | **255 B** (empty) | – | – |
-| Bing | 2,293 B | **169 B** (empty) | **169 B** | 4,153 B |
-| Yandex | **HTTP 204** | 859 B | 107,406 B | **HTTP 204** |
+|        | Paris        | Beijing           | Moscow    | Seattle      |
+| ------ | ------------ | ----------------- | --------- | ------------ |
+| Google | 37,603 B     | **255 B** (empty) | –         | –            |
+| Bing   | 2,293 B      | **169 B** (empty) | **169 B** | 4,153 B      |
+| Yandex | **HTTP 204** | 859 B             | 107,406 B | **HTTP 204** |
 
 Rasterise over country polygons, count coverage-coloured pixels → per-country stats
 for Google, Bing and Yandex. **This is precisely what unlocks the China / Germany /
@@ -175,8 +177,7 @@ by relevance ranking), 2025-06-01 → 2026-08-10:
   **0% reach 500**.
 
 **The big scores in this niche come from third parties, not authors.** Protomaps:
-author 113 pts, a third party 1,001. DeFlock: author 17 pts, third parties 621 / 240 /
-261. The True Size Of: five front pages over ten years, five different submitters.
+author 113 pts, a third party 1,001. DeFlock: author 17 pts, third parties 621 / 240 / 261. The True Size Of: five front pages over ten years, five different submitters.
 → Optimise for re-submittability over a decade, not for launch day.
 
 **Durable multiplier from a spike: 1.1–1.5×.** The only clean ≥60-day measurement in
@@ -184,13 +185,13 @@ the public record is 1.32× (Niko Fischer: 25/day → 11,000 peak → 33/day at 
 months). Restated baseline-independently: **1 in 250 to 1 in 2,000 spike visitors
 becomes a recurring daily visitor.** ~94% bounce, 15–22s average duration.
 
-**Title beats product:** OpenFreeMap posted the *same URL* five days apart —
+**Title beats product:** OpenFreeMap posted the _same URL_ five days apart —
 14 points, then **848 points**. A flop is not a verdict.
 
 Venue ranking by strength of evidence: (1) SEO / per-country pages — the only
 compounding channel; (2) **sk-zk's GitHub Discussions "Show and tell"** — zero
 derived projects ever posted there, sk-zk actively pushing, and
-`streetradar-data-engine` is *already* listed among streetlevel's 26 dependents;
+`streetradar-data-engine` is _already_ listed among streetlevel's 26 dependents;
 (3) OSM wiki `Street-level imagery` — has provider comparison tables and links to no
 coverage map at all; (4) Maps Mania (624 posts tagged "Street View", active); (5) the
 GeoGuessr Discords (61,935 members, no Rule 7); (6) Show HN. **r/geoguessr is the
@@ -206,7 +207,7 @@ upvotes coverage maps to 30k will notice immediately.
 
 ## Decision F — Legal. The exposure is not where I first said it was.
 
-**Revision, and it matters.** I earlier ranked live tile display as the *lower* risk
+**Revision, and it matters.** I earlier ranked live tile display as the _lower_ risk
 because it stores nothing. Two agents argue the opposite and they have the better of
 it on detectability:
 
@@ -214,7 +215,7 @@ it on detectability:
   non-Google maps in the same Customer Application." StreetRadar renders Google
   coverage on a Leaflet/OSM basemap — **continuously, visibly, right now**.
   **Yandex §6.1.1** is identical and names panoramas explicitly.
-- Counterweight, which still holds: the Platform ToS binds *API customers*, and he
+- Counterweight, which still holds: the Platform ToS binds _API customers_, and he
   holds no key. The End User Terms bind instead, and are weaker on this exact point.
 - **Apple Maps ToU §1.3(vi)** remains the clause most squarely on point — "copy,
   extract, scrape or reutilize… creation of any databases based upon data or content
@@ -222,23 +223,23 @@ it on detectability:
 
 **Corrections to what I told the owner earlier:**
 
-1. **The EU sui generis database right is the *weakest* theory, not the key one.**
+1. **The EU sui generis database right is the _weakest_ theory, not the key one.**
    Directive 96/9/EC Art 11 and French CPI L341-2 limit it to EU/EEA makers, and no
    Council extension to third countries has ever been concluded — so Google, Apple,
-   Naver and Yandex are likely **not beneficiaries at all**. On top of that, *BHB v
-   William Hill* (C-203/02) holds the right covers investment in *obtaining* existing
+   Naver and Yandex are likely **not beneficiaries at all**. On top of that, _BHB v
+   William Hill_ (C-203/02) holds the right covers investment in _obtaining_ existing
    materials and "does not cover the resources used for the creation of materials."
-   Coverage imagery is *created* by driving cars, not obtained. Two independent
+   Coverage imagery is _created_ by driving cars, not obtained. Two independent
    reasons the claim probably fails.
-2. **But that helps less than it sounds.** *Ryanair v PR Aviation* (C-30/14): where no
+2. **But that helps less than it sounds.** _Ryanair v PR Aviation_ (C-30/14): where no
    database right exists, the Directive's Art 8 lawful-user protections don't apply
    either, leaving the owner free to impose contractual limits. **No IP right means the
    claim arrives as contract instead.** That is the hiQ endgame — won the CFAA point,
    then lost on contract: Dec 2022 consent judgment, permanent injunction, compelled
    deletion of all derived code and data, $500k, company defunct.
 3. **The serious French exposure is criminal and has nothing to do with IP.**
-   *Cass. crim. 20 May 2015, n° 14-81.336* (Bluetouff): conviction upheld for
-   *maintien frauduleux dans un STAD* where the data was reachable **without
+   _Cass. crim. 20 May 2015, n° 14-81.336_ (Bluetouff): conviction upheld for
+   _maintien frauduleux dans un STAD_ where the data was reachable **without
    credentials**, because the defendant had seen that access controls existed and
    continued anyway. The defence that no offence is committed by "l'internaute qui
    utilise un logiciel grand public pour pénétrer dans un système non protégé" was
@@ -274,11 +275,11 @@ commercial actor.
 
 Verified directly (not agent-reported):
 
-| Provider scraped | Actual host | robots.txt on the called path |
-|---|---|---|
-| Apple | `gspe72-ssl.ls.apple.com/mnn_us/`, `gspe76-ssl.ls.apple.com/api/tile?` | no file served (403) |
-| Naver | `map.pstatic.net` | no file served (Access Denied) |
-| **Já 360** | `ja.is` | **`Disallow: /kort/closest/` + `/kort/scene/`** — the exact two endpoints `streetlevel.ja` calls |
+| Provider scraped | Actual host                                                            | robots.txt on the called path                                                                    |
+| ---------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Apple            | `gspe72-ssl.ls.apple.com/mnn_us/`, `gspe76-ssl.ls.apple.com/api/tile?` | no file served (403)                                                                             |
+| Naver            | `map.pstatic.net`                                                      | no file served (Access Denied)                                                                   |
+| **Já 360**       | `ja.is`                                                                | **`Disallow: /kort/closest/` + `/kort/scene/`** — the exact two endpoints `streetlevel.ja` calls |
 
 Já is the only machine-readable refusal and the only EEA-established maker.
 
@@ -326,7 +327,7 @@ directions: legally and in what could ever be published.
 8. **Do not** build the tile-sampling pipeline. **Do not** monetise.
 
 Open questions the research did not answer: geospatial newsletters as a channel
-(agent failed); community-led growth tactics (agent failed); whether *Ryanair v
-Booking.com*'s 2024 CFAA verdict survived post-trial motions; French *parasitisme /
-concurrence déloyale*, which needs neither an IP right nor a contract and is the
+(agent failed); community-led growth tactics (agent failed); whether _Ryanair v
+Booking.com_'s 2024 CFAA verdict survived post-trial motions; French _parasitisme /
+concurrence déloyale_, which needs neither an IP right nor a contract and is the
 least-examined risk given the owner's jurisdiction.

--- a/docs/STRATEGY-FINDINGS.md
+++ b/docs/STRATEGY-FINDINGS.md
@@ -1,0 +1,332 @@
+# StreetRadar — consolidated research findings
+
+Synthesised 2026-08-10 from 29 research agents (~460k characters of conclusions).
+Raw transcripts: `~/.claude/projects/-home-nnb-StreetRadar/40f71d28-*/subagents/agent-*.jsonl`
+(these get pruned — this file is the durable record).
+
+Two agents returned nothing usable (`ae42b5bffc92640c3` geospatial newsletters,
+`afc0e7d986f55f492` community-led growth). Those questions are unanswered.
+
+**Binding constraint, set by the owner 2026-08-10:** this is a side project and a
+showcase. Not trying to get rich. €10/month is acceptable. Must not be illegal.
+Every recommendation below is re-scored against that, not against growth.
+
+---
+
+## Decision A — Is there a business here? No. Unanimous across five agents.
+
+| Route | Finding | Source |
+|---|---|---|
+| Paid API / dataset sale | No identified buyer. No street-level coverage dataset is sold anywhere, by anyone, at any price. 17 months live, zero inbound commercial enquiry. | SaaS strategist |
+| €1,000 MRR | Needs ~20,000 visitors/month — **40× current traffic** | SaaS strategist |
+| Display ads | **€0.50–1.00/month.** Raptive floor 25,000 pv/mo; Mediavine Journey floor 1,000 sessions (site is at ~half); AdSense payout threshold €70 would take years | Ad monetization |
+| Affiliate | **GeoGuessr has no affiliate program at all** (`/affiliate` 404, `/partners` 404, zero ToS mentions). Referral pays subscription credit and requires you to already be a paying subscriber. Creator program is cosmetics-only, gated at 1,000 followers. Realistic: **€0–5/month** | Affiliate research |
+| Advertiser demand | **CPC $0.00** across essentially the entire keyword cluster | SEO strategist |
+| Ad-blocking | ~**50%** on this specific audience (Plausible measured 58.67% on HN/Reddit traffic; 68.2% desktop; Linux 82.3%). Acceptable Ads would recover half of that — taking €0.65/mo to €1.00/mo | Ad-block research |
+
+Structural note worth keeping: the entire GeoGuessr-alternative ecosystem competes
+*on being free* (Plonk It explicitly: "we don't use ads or charge for any of our
+features"). A category whose value proposition is not-paying has nothing to pay an
+affiliate out of. Not a temporary gap — the category's economics.
+
+**Calibration for the donation route:** OpenFreeMap serves 3bn requests/day at peak
+and displaces ~$6M/month of commercial tiles. Its donations converged to exactly
+$500/month against $500/month of infrastructure. **Net personal income $0.**
+Donations asymptote to costs, never above them.
+
+→ **Decision: closed.** Matches the owner's own position. The research's value here
+is confirming that monetising would be both worthless *and* actively harmful —
+see Decision F.
+
+---
+
+## Decision B — The one technical fix. Do it first.
+
+Found independently by the SEO agent and confirmed in production:
+
+```
+/           → <link rel="canonical" href="https://streetradar.app"/>
+/map        → <link rel="canonical" href="https://streetradar.app"/>   ← wrong
+/analytics  → <link rel="canonical" href="https://streetradar.app"/>   ← wrong
+```
+
+`alternates: { canonical: '/' }` on the root layout propagates to every child that
+doesn't override it. Google treats `rel=canonical` as near-binding consolidation,
+so `/map` and `/analytics` are folded into `/`. **Google has one eligible URL for
+the whole site.** Bing treats it as a hint and keeps indexing — which is exactly
+the 0% Google / 18.5% Bing split that was measured.
+
+Second cause, equally decisive — measured visible word counts from raw HTML:
+
+| URL | Visible words | H1 | JSON-LD |
+|---|---|---|---|
+| `/` | ~90 | brand only, zero keywords | 0 |
+| `/map` | **6** — literally `Loading map...` | **none** | 0 |
+| `/analytics` | 109, mostly nav chrome + "Coming Soon" | present | 0 |
+
+~166 words site-wide. Every chart is `'use client'` fetching JSON at runtime, so the
+entire data asset is invisible in the HTML. Bot blocking was ruled out by test:
+Googlebot, Bingbot and browser UAs all get identical HTTP 200 / 25,884 bytes.
+**Google can crawl fine — it is choosing not to index.**
+
+Also flagged: `/map#12/48.85/2.34/apple,google/osm` permalinks have **zero SEO
+value** — Googlebot discards everything after `#`. Great share links, zero
+indexable URLs. And `www.streetradar.app` returns SSL error 526.
+
+→ **Status: fix pushed on `fix/canonical-urls`, CI green, NOT MERGED.** ~1 day of
+work for the rest. Highest ROI item in the entire corpus.
+
+---
+
+## Decision C — Per-country pages: yes, but not the obvious version
+
+**The finding nobody else surfaced, and it inverts the naive plan.**
+
+Google autocomplete swept across 40 countries for `"does {country} have street
+view"`. **Only 13 autocomplete** — and they are almost exclusively countries where
+coverage is *absent, restricted or surprising*: China, Russia, Germany, Japan,
+Israel, Taiwan, Hong Kong, Turkey, Mexico, Iceland, Switzerland, Poland, UK.
+Volume confirms: china 1,900 · africa 1,300 · india 1,000 · germany 1,000.
+
+Nobody searches "does France have street view." The answer is obviously yes.
+
+**The Apple dataset covers 34 countries — overwhelmingly the obvious-yes ones**
+(France, Spain, Italy, Sweden, Denmark, Belgium, Slovenia…), and holds **no data for
+China, India, Africa, Russia**, where the demand actually is. That inverse
+correlation kills "generate 34 country pages".
+
+**Where the data does match demand:** the updates/history cluster, ~3,220/mo —
+`how often does google street view update` 1,000 · `old street view` 880 ·
+`google street view timeline` 480. The repo holds **586 rows of monthly time series,
+2018-06 → 2025-02, 78 distinct months**. Nobody else publishes provider capture-
+activity over time. Best asset-to-demand fit, currently buried behind a client-side
+chart.
+
+**Search demand, measured rather than estimated:** the Wikipedia article
+`Google_Street_View_coverage` pulls **~10,000–11,100 real views/month** (Wikimedia
+Pageviews API, 12-month mean) — 2.5–3× the entire strict keyword cluster the tools
+can see. Demand arrives through hundreds of floor-censored long-tail phrasings.
+
+Three caveats: the topic is **declining ~30%/yr** (13,389 in 2025 → 8,500 in 2026);
+CPC is $0.00; **Yandex interest collapsed 94%** (25,118 → 1,617) while Apple more
+than doubled.
+
+**Competitive gap is genuinely open.** Per-country *multi-provider* coverage pages do
+not exist anywhere. geomastr has 101 country pages but coverage is one page and
+`/country/japan/` contains the phrase "Street View" **zero times**. geometas country
+pages are 214 words, no tables, no schema. Wikipedia is provider-siloed by design and
+structurally cannot do comparison.
+
+Proposed structure, ~120–180 pages prioritised **by controversy, not data
+availability**: `/coverage/`, `/coverage/[country]/`, `/coverage/apple-look-around/
+[country]/`, `/coverage/history/[year]/`, `/coverage/countries-without-street-view/`,
+`/map/[country]/` (path, never hash).
+
+**Ceiling:** ~400 organic visits/mo at 6 months, **~1,500 at 12 months**, ~3,000 at
+24 months. Not a traffic business. But 0 → 1,500 is a step change from today's
+~110–170 Bing visits.
+
+Explicit do-nots: no 500+ city pages (thin-content classification, and there is no
+city-level query demand); no standalone Bing/Yandex/Naver pages (`Bing_Maps_Streetside`
+Wikipedia gets **~1 view/month**); no mass-generated AI prose; no link buying; don't
+optimise Core Web Vitals (already 0.3–0.5s); don't buy Ahrefs/Semrush.
+
+One tactic worth copying: geomastr allow-lists GPTBot, ClaudeBot, PerplexityBot,
+Google-Extended and CCBot in robots.txt. For a factual-lookup niche, AI-answer
+citation is a real traffic channel.
+
+---
+
+## Decision D — The tile-sampling unlock. **Highest traffic lever, highest legal exposure.**
+
+Verified: all three raster coverage endpoints already in `src/services/
+streetViewService.ts` are publicly samplable and cleanly discriminate coverage at z10.
+
+| | Paris | Beijing | Moscow | Seattle |
+|---|---|---|---|---|
+| Google | 37,603 B | **255 B** (empty) | – | – |
+| Bing | 2,293 B | **169 B** (empty) | **169 B** | 4,153 B |
+| Yandex | **HTTP 204** | 859 B | 107,406 B | **HTTP 204** |
+
+Rasterise over country polygons, count coverage-coloured pixels → per-country stats
+for Google, Bing and Yandex. **This is precisely what unlocks the China / Germany /
+Russia / India pages where the volume is.** Combined with OSM road lengths it yields
+"% of X's roads have Street View" — the metric `ja_stats.json` already proves out
+(59.6% of Icelandic roads).
+
+**And it is the single most legally exposed thing in the entire plan.** Harvesting
+Google's undocumented internal `maps/vt` endpoint to publish a derived statistics
+product is the exact act Platform ToS §3.2.4(c) describes, whose own worked example is
+"construct an index of tree locations within a city from Street View imagery."
+
+→ **Under the owner's constraint, this is the one thing NOT to build.** The traffic it
+unlocks is the traffic that requires crossing the line he drew. The Apple/Naver/Já
+PMTiles are owned outright and stay the safe differentiator.
+
+---
+
+## Decision E — Launching is a lottery ticket, not a plan
+
+Base rates from **n = 13,000 Show HN posts** (Algolia `search_by_date`, so unbiased
+by relevance ranking), 2025-06-01 → 2026-08-10:
+
+- Median Show HN: **2 points.** p90 = 9.
+- Show HN with "map" in the title (n=194): median **2**, **4.6% reach 100 points**,
+  **0% reach 500**.
+
+**The big scores in this niche come from third parties, not authors.** Protomaps:
+author 113 pts, a third party 1,001. DeFlock: author 17 pts, third parties 621 / 240 /
+261. The True Size Of: five front pages over ten years, five different submitters.
+→ Optimise for re-submittability over a decade, not for launch day.
+
+**Durable multiplier from a spike: 1.1–1.5×.** The only clean ≥60-day measurement in
+the public record is 1.32× (Niko Fischer: 25/day → 11,000 peak → 33/day at two
+months). Restated baseline-independently: **1 in 250 to 1 in 2,000 spike visitors
+becomes a recurring daily visitor.** ~94% bounce, 15–22s average duration.
+
+**Title beats product:** OpenFreeMap posted the *same URL* five days apart —
+14 points, then **848 points**. A flop is not a verdict.
+
+Venue ranking by strength of evidence: (1) SEO / per-country pages — the only
+compounding channel; (2) **sk-zk's GitHub Discussions "Show and tell"** — zero
+derived projects ever posted there, sk-zk actively pushing, and
+`streetradar-data-engine` is *already* listed among streetlevel's 26 dependents;
+(3) OSM wiki `Street-level imagery` — has provider comparison tables and links to no
+coverage map at all; (4) Maps Mania (624 posts tagged "Street View", active); (5) the
+GeoGuessr Discords (61,935 members, no Rule 7); (6) Show HN. **r/geoguessr is the
+wrong primary venue** — smallest audience, self-promotion banned by rule, and the five
+non-Google providers are what it cares least about. **r/MapPorn** is where coverage
+maps have cleared 10k–31k upvotes for eight years.
+
+**Hard blocker on every venue:** the data is 11–14 months stale (R2 `last-modified`:
+Apple **2025-06-28**, Naver **2025-09-16**, Já **2025-09-14**). An audience that
+upvotes coverage maps to 30k will notice immediately.
+
+---
+
+## Decision F — Legal. The exposure is not where I first said it was.
+
+**Revision, and it matters.** I earlier ranked live tile display as the *lower* risk
+because it stores nothing. Two agents argue the opposite and they have the better of
+it on detectability:
+
+- **Google Platform ToS §3.2.4(e)(ii)** bans displaying "Street View imagery and
+  non-Google maps in the same Customer Application." StreetRadar renders Google
+  coverage on a Leaflet/OSM basemap — **continuously, visibly, right now**.
+  **Yandex §6.1.1** is identical and names panoramas explicitly.
+- Counterweight, which still holds: the Platform ToS binds *API customers*, and he
+  holds no key. The End User Terms bind instead, and are weaker on this exact point.
+- **Apple Maps ToU §1.3(vi)** remains the clause most squarely on point — "copy,
+  extract, scrape or reutilize… creation of any databases based upon data or content
+  provided through the Service" — and it **binds by access, not signup**.
+
+**Corrections to what I told the owner earlier:**
+
+1. **The EU sui generis database right is the *weakest* theory, not the key one.**
+   Directive 96/9/EC Art 11 and French CPI L341-2 limit it to EU/EEA makers, and no
+   Council extension to third countries has ever been concluded — so Google, Apple,
+   Naver and Yandex are likely **not beneficiaries at all**. On top of that, *BHB v
+   William Hill* (C-203/02) holds the right covers investment in *obtaining* existing
+   materials and "does not cover the resources used for the creation of materials."
+   Coverage imagery is *created* by driving cars, not obtained. Two independent
+   reasons the claim probably fails.
+2. **But that helps less than it sounds.** *Ryanair v PR Aviation* (C-30/14): where no
+   database right exists, the Directive's Art 8 lawful-user protections don't apply
+   either, leaving the owner free to impose contractual limits. **No IP right means the
+   claim arrives as contract instead.** That is the hiQ endgame — won the CFAA point,
+   then lost on contract: Dec 2022 consent judgment, permanent injunction, compelled
+   deletion of all derived code and data, $500k, company defunct.
+3. **The serious French exposure is criminal and has nothing to do with IP.**
+   *Cass. crim. 20 May 2015, n° 14-81.336* (Bluetouff): conviction upheld for
+   *maintien frauduleux dans un STAD* where the data was reachable **without
+   credentials**, because the defendant had seen that access controls existed and
+   continued anyway. The defence that no offence is committed by "l'internaute qui
+   utilise un logiciel grand public pour pénétrer dans un système non protégé" was
+   **rejected**. **Code pénal 323-3**: 5 years / €150,000. Binding French law, applies
+   to an individual in France, and "the endpoint was unauthenticated" is precisely the
+   argument that failed.
+
+**Two precedents that raise the floor:**
+
+- **Yandex sends takedowns against hobby reverse-engineering tools and they work.**
+  Two 2015 GitHub DMCA notices against a "Yandex.Music downloader" on an explicit
+  unauthorized-access-plus-ToS theory; all three targeted repos now return 404. The
+  filer on a 2025 Yandex notice was **Brand Monitor LLC** — outsourced automated brand
+  monitoring, not a human deciding you're too small to bother with.
+- **LDBV/ZSHH v GermanHouseCoordinates** (May 2021), the closest structural analogue:
+  a geodata agency took down a repo republishing extracted coordinates **plus 11 named
+  forks**, asserted database-producer's rights, and disclosed it had seeded fake
+  "dummy-object" **trap records** to detect unauthorized use. Both repos still return
+  **HTTP 451** five years later. Derived tiles inherit source fingerprints.
+
+**What survived, and it's the reason not to panic:** all **21,668 GitHub DMCA notices
+2013–2026** were grepped. **Zero** from Google, Apple, Microsoft, Mapbox, HERE or
+TomTom about map scraping. **Zero** notices mentioning Apple Maps, MapKit or Look
+Around at all. `streetlevel` has shipped public reverse-engineered clients for all six
+providers for 4.5 years, untouched.
+
+**Charging would destroy the best available defence.** The README says "no commercial
+or advertising objectives… purely informational." That sentence is doing real work.
+Monetising deletes it and simultaneously triggers Apple §1.3(iv) ("create or enhance a
+competing service") and Yandex §4.5 ("personal non-commercial use only"). It also
+kills the DSM Art 3 research exception, which is non-overridable but unavailable to a
+commercial actor.
+
+Verified directly (not agent-reported):
+
+| Provider scraped | Actual host | robots.txt on the called path |
+|---|---|---|
+| Apple | `gspe72-ssl.ls.apple.com/mnn_us/`, `gspe76-ssl.ls.apple.com/api/tile?` | no file served (403) |
+| Naver | `map.pstatic.net` | no file served (Access Denied) |
+| **Já 360** | `ja.is` | **`Disallow: /kort/closest/` + `/kort/scene/`** — the exact two endpoints `streetlevel.ja` calls |
+
+Já is the only machine-readable refusal and the only EEA-established maker.
+
+→ **Recommended, cheapest first:** per-provider kill switches (turns an irreversible
+amputation into a 5-minute response to a polite email); restrict the public 16.4 GB R2
+bulk download by Referer/Origin at the Cloudflare edge; keep non-commercial status
+visible; **do not** build Decision D; no proxies. A €200–400 French IP/IT consultation
+is proportionate to the stated goal.
+
+---
+
+## Decision G — The real existential risk is access, not law
+
+**Every Noise at Once** was evergreen for a decade (344 pts and 333 pts on HN in
+separate years) and died when its author was laid off from Spotify and lost data
+access — not to a lawsuit. A tool built on someone else's undocumented pipeline dies
+when the pipeline dies.
+
+Concretely already true here: the Yandex tile URL in the client carries a pinned
+`v=2025.04.14…` that **will** break. Google/Bing/Yandex are hotlinked live, so the
+site's core function depends on three undocumented endpoints nobody has promised to
+keep.
+
+Also: **it is a 3-provider dataset, not 6.** Google, Bing and Yandex are hotlinked
+from the providers' own internal endpoints — none of that data is owned. The owned
+assets are Apple, Naver, Já 360, Mapy.cz. "6 providers" overstates the asset in both
+directions: legally and in what could ever be published.
+
+---
+
+## Recommended sequence under the €10/month + legal constraint
+
+1. **Merge `fix/canonical-urls`** (pushed, green, unmerged — actively suppressing
+   Google indexing of `/map` and `/analytics`).
+2. **Per-provider kill switches** + **R2 Referer/Origin restriction**. Cheap,
+   reversible, reduces exposure at nil product cost.
+3. **SSR text + H1 on `/map`**, JSON-LD, fix `www` SSL 526. ~1 day.
+4. **Refresh Naver and Apple once.** Freeze Já collection but keep serving it, with
+   the kill switch behind it.
+5. **`/coverage/history/[year]/`** from the 586-row time series — the only place the
+   owned data meets real demand.
+6. **`/coverage/apple-look-around/[country]/`** × 34 from `coverage_stats.json`.
+7. **Post to sk-zk's GitHub Discussions**, OSM wiki, Maps Mania. Credit streetlevel
+   by name. Not r/geoguessr first.
+8. **Do not** build the tile-sampling pipeline. **Do not** monetise.
+
+Open questions the research did not answer: geospatial newsletters as a channel
+(agent failed); community-led growth tactics (agent failed); whether *Ryanair v
+Booking.com*'s 2024 CFAA verdict survived post-trial motions; French *parasitisme /
+concurrence déloyale*, which needs neither an IP right nor a contract and is the
+least-examined risk given the owner's jurisdiction.

--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -19,7 +19,8 @@ import type { Metadata } from 'next';
 import CoverageChartWithControls from '@/components/charts/CoverageChartWithControls';
 import SiteHeader from '@/components/layout/siteHeader';
 import SiteFooter from '@/components/layout/siteFooter';
-import { COVERAGE_UPDATED, formatCoverageMonth } from '@/lib/site';
+import JsonLd from '@/components/seo/jsonLd';
+import { COVERAGE_UPDATED, SITE_NAME, SITE_URL, formatCoverageMonth } from '@/lib/site';
 
 export const metadata: Metadata = {
     title: 'Coverage Statistics',
@@ -118,6 +119,24 @@ export default function AnalyticsPage() {
             </main>
 
             <SiteFooter />
+
+            {/* The coverage time series is the one asset here nobody else
+                publishes, so it is worth describing as a dataset rather than
+                leaving it as an unlabelled chart. */}
+            <JsonLd
+                data={{
+                    '@context': 'https://schema.org',
+                    '@type': 'Dataset',
+                    name: 'Street View coverage over time, by provider',
+                    description:
+                        'Monthly street-level imagery coverage by provider and country, ' +
+                        'derived from coverage data collected directly from each provider.',
+                    url: `${SITE_URL}/analytics`,
+                    creator: { '@type': 'Organization', name: SITE_NAME, url: SITE_URL },
+                    isAccessibleForFree: true,
+                    temporalCoverage: `2018-06/${COVERAGE_UPDATED.apple}`,
+                }}
+            />
         </div>
     );
 }

--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -25,6 +25,7 @@ export const metadata: Metadata = {
     title: 'Coverage Statistics',
     description:
         'How Street View coverage has grown over time, by provider and by country. Built from coverage data collected directly from each provider.',
+    alternates: { canonical: '/analytics' },
 };
 
 const upcomingFeatures = [

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -63,9 +63,15 @@ export const metadata: Metadata = {
         'já 360 coverage',
         'panorama coverage map',
     ],
-    alternates: {
-        canonical: '/',
-    },
+    // No `alternates.canonical` here on purpose. Next propagates metadata from
+    // the root layout to every page that does not override it, so a canonical
+    // set at this level made /map and /analytics both emit
+    // <link rel="canonical" href="https://streetradar.app">. Google treats that
+    // as an instruction to fold those URLs into the home page and drop them from
+    // the index — which is a large part of why it sent no traffic at all while
+    // Bing, which treats canonical as a hint, kept indexing them.
+    //
+    // Each page declares its own canonical instead.
     openGraph: {
         type: 'website',
         siteName: SITE_NAME,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,6 +16,7 @@
 import type { Metadata } from 'next';
 import { DM_Sans, Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
+import JsonLd from '@/components/seo/jsonLd';
 import { SITE_DESCRIPTION, SITE_NAME, SITE_URL } from '@/lib/site';
 
 // Configuration of Geist fonts (sans-serif) and Geist Mono (monospace)
@@ -106,6 +107,19 @@ export default function RootLayout({
                 className={`${dmSans.variable} ${geistSans.variable} ${geistMono.variable} antialiased`}
             >
                 {children}
+                {/* Site-level structured data. Emitted once here rather than per
+                    page so the WebSite node cannot disagree with itself. */}
+                <JsonLd
+                    data={{
+                        '@context': 'https://schema.org',
+                        '@type': 'WebSite',
+                        name: SITE_NAME,
+                        alternateName: 'Street View coverage map',
+                        url: SITE_URL,
+                        description: SITE_DESCRIPTION,
+                        inLanguage: 'en',
+                    }}
+                />
             </body>
         </html>
     );

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -13,13 +13,7 @@ import Link from 'next/link';
 import MapWrapper from '@/components/map/mapWrapper';
 import JsonLd from '@/components/seo/jsonLd';
 import type { Metadata } from 'next';
-import {
-    COVERAGE_UPDATED,
-    PROVIDERS,
-    SITE_NAME,
-    SITE_URL,
-    formatCoverageMonth,
-} from '@/lib/site';
+import { COVERAGE_UPDATED, PROVIDERS, SITE_NAME, SITE_URL, formatCoverageMonth } from '@/lib/site';
 
 // Map page specific metadata
 export const metadata: Metadata = {
@@ -63,22 +57,17 @@ export default function MapPage() {
 
             <section className="bg-background py-16">
                 <div className="container">
-                    <h2 className="text-ink mb-5 text-2xl font-semibold">
-                        What this map shows
-                    </h2>
+                    <h2 className="text-ink mb-5 text-2xl font-semibold">What this map shows</h2>
                     <p className="text-ink-light mb-10 max-w-[70ch] leading-[1.6]">
-                        Every provider publishes street-level imagery for a different part
-                        of the world, and none of them will tell you where the others have
-                        been. This map puts all six coverage networks in one place, so you
-                        can see at a glance whether a given road has been photographed —
-                        and by whom. Click anywhere to check which providers have a
-                        panorama near that point, then open it directly in the provider’s
-                        own viewer.
+                        Every provider publishes street-level imagery for a different part of the
+                        world, and none of them will tell you where the others have been. This map
+                        puts all six coverage networks in one place, so you can see at a glance
+                        whether a given road has been photographed — and by whom. Click anywhere to
+                        check which providers have a panorama near that point, then open it directly
+                        in the provider’s own viewer.
                     </p>
 
-                    <h2 className="text-ink mb-5 text-2xl font-semibold">
-                        The six providers
-                    </h2>
+                    <h2 className="text-ink mb-5 text-2xl font-semibold">The six providers</h2>
                     <dl className="mb-10 grid max-w-[70ch] gap-5">
                         {PROVIDERS.map((provider) => (
                             <div key={provider.id}>
@@ -87,17 +76,14 @@ export default function MapPage() {
                                     {provider.blurb}{' '}
                                     {provider.source === 'live' ? (
                                         <span>
-                                            This layer is requested live as you pan, so it
-                                            is always current.
+                                            This layer is requested live as you pan, so it is always
+                                            current.
                                         </span>
                                     ) : (
                                         <span>
-                                            This layer is built from coverage collected
-                                            for this site, last rebuilt in{' '}
-                                            {formatCoverageMonth(
-                                                COVERAGE_UPDATED[provider.id]
-                                            )}
-                                            .
+                                            This layer is built from coverage collected for this
+                                            site, last rebuilt in{' '}
+                                            {formatCoverageMonth(COVERAGE_UPDATED[provider.id])}.
                                         </span>
                                     )}
                                 </dd>

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -9,8 +9,17 @@
  * the map component on the client side to avoid SSR issues.
  */
 
+import Link from 'next/link';
 import MapWrapper from '@/components/map/mapWrapper';
+import JsonLd from '@/components/seo/jsonLd';
 import type { Metadata } from 'next';
+import {
+    COVERAGE_UPDATED,
+    PROVIDERS,
+    SITE_NAME,
+    SITE_URL,
+    formatCoverageMonth,
+} from '@/lib/site';
 
 // Map page specific metadata
 export const metadata: Metadata = {
@@ -39,9 +48,94 @@ export default function MapPage() {
         // introduce a second, competing sizing mechanism. Converting this page
         // properly is a separate change.
         <main>
+            {/* Until now this page server-rendered six words — the string
+                "Loading map..." inside mapWrapper's dynamic() fallback — and no
+                heading at all, because the map is client-only. That is the whole
+                indexable surface a crawler ever saw. The heading is visually
+                hidden because the map fills the viewport and there is nowhere to
+                put it, but it is the page's real subject, not keyword filler:
+                the prose below says the same thing at length. */}
+            <h1 className="sr-only">Street View coverage map</h1>
+
             <div>
                 <MapWrapper />
             </div>
+
+            <section className="bg-background py-16">
+                <div className="container">
+                    <h2 className="text-ink mb-5 text-2xl font-semibold">
+                        What this map shows
+                    </h2>
+                    <p className="text-ink-light mb-10 max-w-[70ch] leading-[1.6]">
+                        Every provider publishes street-level imagery for a different part
+                        of the world, and none of them will tell you where the others have
+                        been. This map puts all six coverage networks in one place, so you
+                        can see at a glance whether a given road has been photographed —
+                        and by whom. Click anywhere to check which providers have a
+                        panorama near that point, then open it directly in the provider’s
+                        own viewer.
+                    </p>
+
+                    <h2 className="text-ink mb-5 text-2xl font-semibold">
+                        The six providers
+                    </h2>
+                    <dl className="mb-10 grid max-w-[70ch] gap-5">
+                        {PROVIDERS.map((provider) => (
+                            <div key={provider.id}>
+                                <dt className="text-ink font-medium">{provider.name}</dt>
+                                <dd className="text-ink-light leading-[1.6]">
+                                    {provider.blurb}{' '}
+                                    {provider.source === 'live' ? (
+                                        <span>
+                                            This layer is requested live as you pan, so it
+                                            is always current.
+                                        </span>
+                                    ) : (
+                                        <span>
+                                            This layer is built from coverage collected
+                                            for this site, last rebuilt in{' '}
+                                            {formatCoverageMonth(
+                                                COVERAGE_UPDATED[provider.id]
+                                            )}
+                                            .
+                                        </span>
+                                    )}
+                                </dd>
+                            </div>
+                        ))}
+                    </dl>
+
+                    <p className="text-ink-light">
+                        Curious how coverage has grown over time?{' '}
+                        <Link href="/analytics" className="text-primary underline">
+                            See the coverage statistics
+                        </Link>
+                        , or read more{' '}
+                        <Link href="/" className="text-primary underline">
+                            about StreetRadar
+                        </Link>
+                        .
+                    </p>
+                </div>
+            </section>
+
+            <JsonLd
+                data={{
+                    '@context': 'https://schema.org',
+                    '@type': 'WebApplication',
+                    name: `${SITE_NAME} coverage map`,
+                    url: `${SITE_URL}/map`,
+                    applicationCategory: 'BrowserApplication',
+                    operatingSystem: 'Any',
+                    browserRequirements: 'Requires JavaScript.',
+                    description:
+                        'Interactive map of worldwide street-level imagery coverage from ' +
+                        'Google Street View, Apple Look Around, Bing Streetside, Yandex ' +
+                        'Panoramas, Naver Street View and Já 360.',
+                    isAccessibleForFree: true,
+                    offers: { '@type': 'Offer', price: '0', priceCurrency: 'EUR' },
+                }}
+            />
         </main>
     );
 }

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -19,6 +19,7 @@ export const metadata: Metadata = {
         'Explore worldwide Street View coverage from Google, Bing, Yandex and Apple. Click anywhere to find available panoramas and discover street-level imagery around the world.',
     keywords:
         'street view, google maps, bing streetside, yandex panoramas, apple look around, coverage map, panoramas',
+    alternates: { canonical: '/map' },
     openGraph: {
         title: 'StreetRadar - Interactive Street View Coverage Map',
         description:

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,10 +12,15 @@
  * Server component: no state, no client JS.
  */
 
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
 import SiteHeader from '@/components/layout/siteHeader';
 import SiteFooter from '@/components/layout/siteFooter';
+
+export const metadata: Metadata = {
+    alternates: { canonical: '/' },
+};
 
 const PROVIDERS = [
     { id: 'google', name: 'Google Street View', logo: '/images/providers/google.svg' },

--- a/src/components/charts/TimelineChart.tsx
+++ b/src/components/charts/TimelineChart.tsx
@@ -400,7 +400,7 @@ const TimelineChart: React.FC<TimelineChartProps> = ({
                         }}
                     ></div>
                     <p style={{ margin: 0, fontSize: '14px', fontWeight: '500' }}>
-                        Chargement de la timeline...
+                        Loading timeline...
                     </p>
                 </div>
             </div>

--- a/src/components/seo/jsonLd.tsx
+++ b/src/components/seo/jsonLd.tsx
@@ -1,0 +1,28 @@
+/**
+ * jsonLd.tsx
+ *
+ * Emits a JSON-LD block. The site had no structured data at all, which meant
+ * search engines had to infer what it is from ~166 words of visible text.
+ *
+ * Next has no first-class API for this, so a script tag with
+ * dangerouslySetInnerHTML is the documented approach. The payload is built
+ * server-side from our own constants and never from user input, so there is
+ * nothing to escape beyond `<` — which JSON.stringify leaves alone and which
+ * would otherwise let a `</script>` sequence break out of the tag.
+ */
+
+interface JsonLdProps {
+    /** A schema.org node. Serialised as-is. */
+    data: Record<string, unknown>;
+}
+
+export default function JsonLd({ data }: JsonLdProps) {
+    return (
+        <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{
+                __html: JSON.stringify(data).replace(/</g, '\\u003c'),
+            }}
+        />
+    );
+}

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -32,6 +32,65 @@ export const COVERAGE_UPDATED: Record<string, string> = {
     naver: '2025-09',
 };
 
+/**
+ * The providers shown on the map, and — importantly — how each layer is served.
+ *
+ * `live` layers are requested by the visitor's browser from the provider on
+ * demand; nothing is stored here and there is no freshness date to give.
+ * `collected` layers are built from coverage we gathered ourselves, so they
+ * carry a date from COVERAGE_UPDATED and go stale between pipeline runs.
+ *
+ * The distinction matters to a visitor trying to work out why one layer is
+ * current and another is a year old, so it is stated on the map page rather
+ * than left for them to guess.
+ */
+export interface Provider {
+    id: string;
+    name: string;
+    /** One sentence a visitor who has never heard of it can use. */
+    blurb: string;
+    source: 'live' | 'collected';
+}
+
+export const PROVIDERS: Provider[] = [
+    {
+        id: 'google',
+        name: 'Google Street View',
+        blurb: 'The largest network by far, covering most of the road network in over 100 countries.',
+        source: 'live',
+    },
+    {
+        id: 'apple',
+        name: 'Apple Look Around',
+        blurb: "Apple's equivalent, launched in 2019 and still limited to a few dozen countries.",
+        source: 'collected',
+    },
+    {
+        id: 'bing',
+        name: 'Bing Streetside',
+        blurb: "Microsoft's network, concentrated in North America and Western Europe.",
+        source: 'live',
+    },
+    {
+        id: 'yandex',
+        name: 'Yandex Panoramas',
+        blurb: 'The most detailed coverage of Russia, Central Asia and the Caucasus.',
+        source: 'live',
+    },
+    {
+        id: 'naver',
+        name: 'Naver Street View',
+        blurb: 'Dense coverage of South Korea, where Google’s is restricted.',
+        source: 'collected',
+    },
+    {
+        id: 'ja',
+        name: 'Já 360',
+        blurb: 'An Icelandic directory service whose imagery covers 59.6% of the road network.',
+        source: 'collected',
+    },
+];
+
 /** The oldest of the per-provider dates — what the site as a whole can claim. */
 export function oldestCoverageDate(): string {
     return Object.values(COVERAGE_UPDATED).sort()[0];


### PR DESCRIPTION
Phase 5 of the cleanup: unblock search indexing. Four commits, all free, none optional.

## The canonical bug

`alternates: { canonical: '/' }` was set on the root layout. Next propagates root-layout metadata to every page that does not override it, and neither `/map` nor `/analytics` did — so all three URLs emitted the identical tag:

```
/           <link rel="canonical" href="https://streetradar.app">
/map        <link rel="canonical" href="https://streetradar.app">
/analytics  <link rel="canonical" href="https://streetradar.app">
```

Google treats `rel=canonical` as a near-binding consolidation instruction, so two thirds of the site were folded into the home page and dropped from the index. Bing treats it as a hint and kept indexing — which is exactly the asymmetry measured last week: **18.5% of referrals from Bing, 0.0% from Google**.

This was introduced in #39. Each page now declares its own canonical and the root layout carries a comment explaining why it must not.

## Giving those pages a reason to be kept

Measured from the raw HTML before this change:

| URL | Visible words | H1 | JSON-LD |
|---|---|---|---|
| `/` | ~90 | brand name alone | 0 |
| `/map` | **6** — `Loading map...` | **none** | 0 |
| `/analytics` | 109, mostly nav chrome | present | 0 |

~166 words site-wide. The map is client-only, so its whole indexable surface was the `dynamic()` loading placeholder.

`/map` now server-renders **281 words**: what the map is for, and one entry per provider. That list also states something a visitor could not otherwise work out — three layers are fetched live from the provider as you pan, three are built from coverage collected for this site and carry a rebuild date. The provider list moves into `lib/site.ts`, which already claimed to own it.

The H1 is `sr-only`: the map fills the viewport and there is nowhere to put a visible heading without introducing a second sizing mechanism. The prose below says the same thing at length, so this is a heading for a page that had none.

JSON-LD added: `WebSite` on the root layout, `WebApplication` on `/map`, `Dataset` on `/analytics` with `temporalCoverage` `2018-06/2025-02`.

Also fixes the last French string in `src/` — `TimelineChart` rendered "Chargement de la timeline..." on every analytics chart load.

## Verification

Against a production build served locally:

- three distinct canonicals
- `/map`: 281 visible words, H1 present and correctly hidden
- Leaflet still initialises, 108 tiles loaded
- the new section starts at exactly the pixel the map ends — no overlap, no gap
- no horizontal overflow
- a wheel event over the map still zooms (3 → 6) and does **not** scroll the page, which was the regression risk in making this page scrollable

`tsc --noEmit` clean, eslint clean, `next build` green.

## Also included

`docs/STRATEGY-FINDINGS.md` — the decision-level consolidation of 29 research agents (~460k characters of conclusions) that otherwise only existed as jsonl transcripts that get pruned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)