### PR TITLE
Per-provider kill switch, and the runbook for using it

### DIFF
--- a/docs/RUNBOOK-takedown.md
+++ b/docs/RUNBOOK-takedown.md
@@ -1,0 +1,152 @@
+# Runbook — a provider asks us to stop, or someone is mirroring the tiles
+
+Two separate situations. The first is urgent and fully automated. The second is
+housekeeping that should be done once, in advance.
+
+---
+
+## 1. A provider asks us to stop
+
+Expected form: a polite email, or a GitHub DMCA notice. Not a lawsuit — across
+all 21,668 GitHub DMCA notices from 2013 to 2026 there is not one from Google,
+Apple, Microsoft, Mapbox, HERE or TomTom about map scraping. Yandex is the
+outlier that has acted before, via an automated brand-monitoring contractor.
+
+**Do this first, before replying.** It takes about a minute and makes the reply
+easy to write.
+
+1.  In Vercel → Project → Settings → Environment Variables, set
+
+        NEXT_PUBLIC_DISABLED_PROVIDERS = ja
+
+    Comma-separated for several: `ja,naver`. Valid ids are exactly the `id`
+    values in `src/lib/site.ts`: `google`, `apple`, `bing`, `yandex`, `naver`,
+    `ja`.
+
+2.  Redeploy (Vercel → Deployments → ⋯ → Redeploy). The variable is inlined into
+    the client bundle at build time, so a redeploy is required — restarting is
+    not enough.
+
+3.  Confirm. The provider must be gone from all of these:
+
+        curl -s https://streetradar.app/map | grep -c 'Já'          # expect 0
+        curl -s https://streetradar.app/     | grep -c 'Já'          # expect 0
+
+    And in a browser on `/map`, the layer control should no longer list it.
+
+What the switch covers, verified in a browser both ways:
+
+- the layer control, and the layer component is not mounted at all — so not one
+  tile request can originate from the site
+- the click-detection query, filtered separately rather than trusting the layer
+  state
+- the URL hash: an old shared permalink naming the provider has it stripped, so
+  it cannot be switched back on
+- the home page and `/map` provider lists
+- the meta description, Open Graph card and JSON-LD — the strings that search
+  engines and social platforms cache, and therefore outlive the deploy
+
+4. Only then, stop the collector. Nothing in `streetradar-data-engine` runs on a
+   schedule, so there is no job to cancel — just do not run
+   `scripts/<provider>/collect_data.py` again.
+
+5. The stored data is a separate decision from serving it. Disabling the
+   provider stops the site requesting the tiles, but the PMTiles file stays on
+   R2 and remains publicly downloadable at
+   `https://tiles.streetradar.app/<name>.pmtiles`. If the request was to remove
+   the data, delete the object from the bucket too, or §2 below will not be
+   enough.
+
+---
+
+## 2. Restricting the public tile download
+
+Current state, measured 2026-08-10:
+
+| File                    | Size            | Last modified |
+| ----------------------- | --------------- | ------------- |
+| `tiles.pmtiles` (Apple) | 6,221,493,285 B | 2025-06-28    |
+| `naver.pmtiles`         | 9,252,567,760 B | 2025-09-16    |
+| `ja360.pmtiles`         | 884,115,233 B   | 2025-09-14    |
+| **total**               | **16.36 GB**    |               |
+
+`tiles.streetradar.app` is an R2 custom domain with no protection whatsoever:
+
+- an anonymous range request with no `Referer` returns `206`
+- any `Referer` value is accepted
+- **the CORS policy is `access-control-allow-origin: *`**, so any website can
+  embed these tiles in a visitor's browser
+
+None of this can be fixed from the codebase — the map has to be able to fetch
+the tiles, so every real control is edge or bucket configuration. The three
+below are ranked by how much they actually accomplish.
+
+### 2a. Tighten the R2 CORS policy — do this one
+
+R2 → the bucket behind `tiles.streetradar.app` → Settings → CORS policy:
+
+```json
+[
+    {
+        "AllowedOrigins": ["https://streetradar.app"],
+        "AllowedMethods": ["GET", "HEAD"],
+        "AllowedHeaders": ["range"],
+        "ExposeHeaders": ["Content-Range", "Content-Length", "ETag"],
+        "MaxAgeSeconds": 3600
+    }
+]
+```
+
+This is the only control in this list that is genuinely enforced rather than
+advisory: the _browser_ refuses to hand the response to a page from another
+origin. It stops third-party sites building on our bandwidth. It does not stop
+`curl`, and it is not meant to.
+
+Check afterwards that the map still works — `MaxAgeSeconds` means a stale
+preflight can be cached for an hour, so test in a fresh private window.
+
+### 2b. Turn off the R2 public development URL
+
+R2 → bucket → Settings → Public Development URL must be **disabled**. If a
+`pub-<hash>.r2.dev` URL is live, it bypasses the custom domain entirely and
+every rule below is decorative. Worth checking even though nothing references
+it — it is a one-click setting that is easy to have left on.
+
+### 2c. Rate-limit the tile host
+
+A WAF rate-limiting rule on `tiles.streetradar.app`. This is the control that
+cannot be defeated by forging a header, and it maps onto the actual harm, which
+is someone pulling 16 GB rather than someone looking at a map.
+
+The two cases separate cleanly. A real map session issues on the order of
+**26 range requests for a few hundred kilobytes**, measured. A mirror pulls
+gigabytes. So a per-IP ceiling well above the first and far below the second
+costs legitimate visitors nothing.
+
+Expression: `http.host eq "tiles.streetradar.app"`, counting requests per IP,
+action _Block_. Pick a threshold from the numbers above rather than from a
+default.
+
+### What not to bother with
+
+A WAF rule matching on `Referer` or `Origin`. It reads as protection but is one
+`-H` flag away from useless, and it breaks the moment a browser omits the header
+for a legitimate reason. If you want it anyway, do it _in addition to_ 2c, never
+instead of it.
+
+### Access needed
+
+None of the above can be applied with the Cloudflare OAuth token wrangler
+currently holds — it grants `zone (read)`, and these need bucket-level R2 write
+plus zone rules edit. Either do it in the dashboard, or issue an API token with
+**R2: Edit** and **Zone → Rules: Edit** scoped to this zone.
+
+---
+
+## 3. Also outstanding
+
+`www.streetradar.app` returns **HTTP 526**. There is no `www` DNS record in the
+zone, so it resolves through a wildcard, reaches Vercel, which holds no
+certificate for that name, and Cloudflare in Full (strict) rejects it. Fix by
+adding `www.streetradar.app` as a domain in the Vercel project — Vercel issues
+the certificate and can redirect it to the apex.

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -13,7 +13,14 @@ import Link from 'next/link';
 import MapWrapper from '@/components/map/mapWrapper';
 import JsonLd from '@/components/seo/jsonLd';
 import type { Metadata } from 'next';
-import { COVERAGE_UPDATED, PROVIDERS, SITE_NAME, SITE_URL, formatCoverageMonth } from '@/lib/site';
+import {
+    COVERAGE_UPDATED,
+    ENABLED_PROVIDERS,
+    listProviderNames,
+    SITE_NAME,
+    SITE_URL,
+    formatCoverageMonth,
+} from '@/lib/site';
 
 // Map page specific metadata
 export const metadata: Metadata = {
@@ -67,9 +74,9 @@ export default function MapPage() {
                         in the provider’s own viewer.
                     </p>
 
-                    <h2 className="text-ink mb-5 text-2xl font-semibold">The six providers</h2>
+                    <h2 className="text-ink mb-5 text-2xl font-semibold">The providers</h2>
                     <dl className="mb-10 grid max-w-[70ch] gap-5">
-                        {PROVIDERS.map((provider) => (
+                        {ENABLED_PROVIDERS.map((provider) => (
                             <div key={provider.id}>
                                 <dt className="text-ink font-medium">{provider.name}</dt>
                                 <dd className="text-ink-light leading-[1.6]">
@@ -114,10 +121,7 @@ export default function MapPage() {
                     applicationCategory: 'BrowserApplication',
                     operatingSystem: 'Any',
                     browserRequirements: 'Requires JavaScript.',
-                    description:
-                        'Interactive map of worldwide street-level imagery coverage from ' +
-                        'Google Street View, Apple Look Around, Bing Streetside, Yandex ' +
-                        'Panoramas, Naver Street View and Já 360.',
+                    description: `Interactive map of worldwide street-level imagery coverage from ${listProviderNames()}.`,
                     isAccessibleForFree: true,
                     offers: { '@type': 'Offer', price: '0', priceCurrency: 'EUR' },
                 }}

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -12,9 +12,9 @@
  */
 
 import { ImageResponse } from 'next/og';
-import { SITE_NAME, formatCoverageMonth, oldestCoverageDate } from '@/lib/site';
+import { ENABLED_PROVIDERS, SITE_NAME, formatCoverageMonth, oldestCoverageDate } from '@/lib/site';
 
-export const alt = 'StreetRadar — Street View coverage from six providers on one map';
+export const alt = `StreetRadar — Street View coverage from ${ENABLED_PROVIDERS.length} providers on one map`;
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
@@ -25,9 +25,15 @@ const SECONDARY = '#337b81';
 const TEXT = '#333333';
 const TEXT_LIGHT = '#666666';
 
-const PROVIDERS = ['Google', 'Apple', 'Bing', 'Yandex', 'Naver', 'Já 360'];
+// Derived, so a provider taken off the site is not still advertised on the
+// social card — which is cached by every platform that has ever fetched it.
+const PROVIDERS = ENABLED_PROVIDERS.map((provider) => provider.shortName);
 
 export default async function Image() {
+    // Null when every collected layer is switched off, in which case there is no
+    // rebuild date the card can honestly quote.
+    const coverageDate = oldestCoverageDate();
+
     return new ImageResponse(
         (
             <div
@@ -66,7 +72,7 @@ export default async function Image() {
                             maxWidth: 900,
                         }}
                     >
-                        See where Street View imagery exists worldwide — six providers on one map.
+                        {`See where Street View imagery exists worldwide — ${ENABLED_PROVIDERS.length} providers on one map.`}
                     </div>
                 </div>
 
@@ -89,7 +95,9 @@ export default async function Image() {
                         ))}
                     </div>
                     <div style={{ display: 'flex', fontSize: 24, color: TEXT_LIGHT }}>
-                        streetradar.app · coverage data {formatCoverageMonth(oldestCoverageDate())}
+                        {coverageDate
+                            ? `streetradar.app · coverage data ${formatCoverageMonth(coverageDate)}`
+                            : 'streetradar.app'}
                     </div>
                 </div>
             </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,19 +17,11 @@ import Link from 'next/link';
 import Image from 'next/image';
 import SiteHeader from '@/components/layout/siteHeader';
 import SiteFooter from '@/components/layout/siteFooter';
+import { ENABLED_PROVIDERS } from '@/lib/site';
 
 export const metadata: Metadata = {
     alternates: { canonical: '/' },
 };
-
-const PROVIDERS = [
-    { id: 'google', name: 'Google Street View', logo: '/images/providers/google.svg' },
-    { id: 'apple', name: 'Apple Look Around', logo: '/images/providers/apple.svg' },
-    { id: 'bing', name: 'Bing Streetside', logo: '/images/providers/bing.svg' },
-    { id: 'yandex', name: 'Yandex Panoramas', logo: '/images/providers/yandex.svg' },
-    { id: 'naver', name: 'Naver Street View', logo: '/images/providers/naver.svg' },
-    { id: 'ja', name: 'Já 360 Street View', logo: '/images/providers/ja.svg' },
-];
 
 export default function Home() {
     return (
@@ -71,7 +63,7 @@ export default function Home() {
                         Supported Providers
                     </h2>
                     <div className="grid grid-cols-[repeat(auto-fit,minmax(250px,1fr))] gap-[30px] max-md:grid-cols-1">
-                        {PROVIDERS.map((provider) => (
+                        {ENABLED_PROVIDERS.map((provider) => (
                             <div
                                 key={provider.id}
                                 className="odd:hover:border-l-primary even:hover:border-l-secondary flex items-center rounded-lg bg-white/50 p-5 transition-[transform,box-shadow] duration-300 hover:-translate-y-[3px] hover:border-l-[3px] hover:shadow-[0_10px_20px_rgba(0,0,0,0.05)]"

--- a/src/components/layout/siteFooter.tsx
+++ b/src/components/layout/siteFooter.tsx
@@ -6,9 +6,12 @@
  */
 
 import Image from 'next/image';
-import { COVERAGE_UPDATED, formatCoverageMonth, oldestCoverageDate } from '@/lib/site';
+import { formatCoverageMonth, newestCoverageDate, oldestCoverageDate } from '@/lib/site';
 
 export default function SiteFooter() {
+    const oldest = oldestCoverageDate();
+    const newest = newestCoverageDate();
+
     return (
         <footer className="border-t border-black/5 bg-white/30 py-10">
             <div className="container flex items-center justify-between gap-5 max-md:flex-col max-md:text-center">
@@ -26,10 +29,15 @@ export default function SiteFooter() {
                         © {new Date().getFullYear()} StreetRadar v0.1
                     </span>
                 </div>
-                <span className="text-ink-light text-sm">
-                    Coverage data {formatCoverageMonth(oldestCoverageDate())}
-                    {COVERAGE_UPDATED.apple !== oldestCoverageDate() && ' or newer'}
-                </span>
+                {/* Null when every collected layer is switched off — the site is
+                    then only showing live provider layers, which have no rebuild
+                    date to apologise for. */}
+                {oldest && (
+                    <span className="text-ink-light text-sm">
+                        Coverage data {formatCoverageMonth(oldest)}
+                        {newest !== oldest && ' or newer'}
+                    </span>
+                )}
             </div>
         </footer>
     );

--- a/src/components/map/mapContainer.tsx
+++ b/src/components/map/mapContainer.tsx
@@ -11,7 +11,8 @@
 import { useEffect, useRef, useState } from 'react';
 
 import { readMapHash, useMapUrlState } from '@/hooks/useMapUrlState';
-import type { Basemap } from '@/lib/mapUrlState';
+import { LAYER_KEY_TO_SLUG, type Basemap, type LayerSlug } from '@/lib/mapUrlState';
+import { isProviderEnabled } from '@/lib/site';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import '@/styles/leafletStyles.css';
@@ -62,13 +63,23 @@ export default function MapContainer({
             jaStreetView: false,
         };
 
+        // A killed provider stays off whatever the defaults or the link say, so
+        // an old shared permalink cannot switch it back on. Note this is a
+        // separate question from whether a layer is on by default: Apple and Já
+        // are both off by default and must still be reachable from a link.
+        const killed = (key: keyof typeof defaults) => !isProviderEnabled(LAYER_KEY_TO_SLUG[key]);
+
+        for (const key of Object.keys(defaults) as (keyof typeof defaults)[]) {
+            if (killed(key)) defaults[key] = false;
+        }
+
         // A link with no layer section keeps the defaults; one that lists none
         // meant it, and gets an empty map.
         if (!initialUrlState?.layers) return defaults;
 
         const fromUrl = { ...defaults };
         for (const key of Object.keys(fromUrl) as (keyof typeof fromUrl)[]) {
-            fromUrl[key] = initialUrlState.layers.includes(key);
+            fromUrl[key] = !killed(key) && initialUrlState.layers.includes(key);
         }
         return fromUrl;
     });
@@ -109,10 +120,19 @@ export default function MapContainer({
     // Minimum zoom level to activate Street View - reduced by 6 levels total (16 -> 13 -> 10)
     const MIN_ZOOM_FOR_STREETVIEW = 10;
 
-    // Provider configuration with their information
-    const providers = [
+    // Provider configuration with their information. Filtered by the kill
+    // switch, so a disabled provider is never offered in the control.
+    const allProviders: {
+        key: keyof typeof visibleLayers;
+        id: LayerSlug;
+        name: string;
+        shortName: string;
+        logo: string;
+        color: string;
+    }[] = [
         {
             key: 'googleStreetView',
+            id: 'google',
             name: 'Street View',
             shortName: 'Google',
             logo: '/images/providers/google.svg',
@@ -120,6 +140,7 @@ export default function MapContainer({
         },
         {
             key: 'bingStreetside',
+            id: 'bing',
             name: 'Streetside',
             shortName: 'Bing',
             logo: '/images/providers/bing.svg',
@@ -127,6 +148,7 @@ export default function MapContainer({
         },
         {
             key: 'appleLookAround',
+            id: 'apple',
             name: 'Look Around',
             shortName: 'Apple',
             logo: '/images/providers/apple.svg',
@@ -134,6 +156,7 @@ export default function MapContainer({
         },
         {
             key: 'yandexPanoramas',
+            id: 'yandex',
             name: 'Panoramas',
             shortName: 'Yandex',
             logo: '/images/providers/yandex.svg',
@@ -141,6 +164,7 @@ export default function MapContainer({
         },
         {
             key: 'naverStreetView',
+            id: 'naver',
             name: 'Street View',
             shortName: 'Naver',
             logo: '/images/providers/naver.svg',
@@ -148,12 +172,14 @@ export default function MapContainer({
         },
         {
             key: 'jaStreetView',
+            id: 'ja',
             name: 'Já 360',
             shortName: 'Já 360',
             logo: '/images/providers/ja.svg',
             color: '#ff6b35',
         },
     ];
+    const providers = allProviders.filter((provider) => isProviderEnabled(provider.id));
 
     // Initialize Leaflet map
     useEffect(() => {
@@ -536,36 +562,16 @@ export default function MapContainer({
             {/* Street View layer components */}
             {mapInstance && (
                 <>
-                    <StreetViewLayer
-                        map={mapInstance}
-                        provider="google"
-                        visible={visibleLayers.googleStreetView}
-                    />
-                    <StreetViewLayer
-                        map={mapInstance}
-                        provider="bing"
-                        visible={visibleLayers.bingStreetside}
-                    />
-                    <StreetViewLayer
-                        map={mapInstance}
-                        provider="yandex"
-                        visible={visibleLayers.yandexPanoramas}
-                    />
-                    <StreetViewLayer
-                        map={mapInstance}
-                        provider="apple"
-                        visible={visibleLayers.appleLookAround}
-                    />
-                    <StreetViewLayer
-                        map={mapInstance}
-                        provider="naver"
-                        visible={visibleLayers.naverStreetView}
-                    />
-                    <StreetViewLayer
-                        map={mapInstance}
-                        provider="ja"
-                        visible={visibleLayers.jaStreetView}
-                    />
+                    {/* Only enabled providers are mounted at all, so a disabled
+                        one cannot issue a single tile request. */}
+                    {providers.map((provider) => (
+                        <StreetViewLayer
+                            key={provider.id}
+                            map={mapInstance}
+                            provider={provider.id}
+                            visible={visibleLayers[provider.key as keyof typeof visibleLayers]}
+                        />
+                    ))}
                 </>
             )}
 

--- a/src/hooks/usePanoramaDetection.ts
+++ b/src/hooks/usePanoramaDetection.ts
@@ -12,6 +12,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { activeProviderIds } from '@/lib/mapUrlState';
 import type L from 'leaflet';
 import { PanoramaService } from '@/services/panoramaService';
 import type { StreetViewDetectionResult } from '@/services/streetViewDetectionCanvas';
@@ -26,24 +27,6 @@ export interface ClickInfo {
     position: L.LatLng | null;
     type: 'click' | 'drop';
     timestamp: number;
-}
-
-/**
- * Turns the layer state keys into the provider ids PanoramaService expects:
- * googleStreetView -> google, appleLookAround -> apple, jaStreetView -> ja.
- */
-export function activeProviderIds(visibleLayers: Record<string, boolean>): string[] {
-    return Object.entries(visibleLayers)
-        .filter(([, isVisible]) => isVisible)
-        .map(([layer]) => {
-            if (layer === 'jaStreetView') return 'ja';
-            return layer
-                .replace('StreetView', '')
-                .replace('Streetside', '')
-                .replace('Panoramas', '')
-                .replace('LookAround', '')
-                .toLowerCase();
-        });
 }
 
 interface Options {

--- a/src/lib/mapUrlState.ts
+++ b/src/lib/mapUrlState.ts
@@ -15,6 +15,8 @@
  * updating it never round-trips to the server.
  */
 
+import { isProviderEnabled } from '@/lib/site';
+
 /** URL slug -> the key used in the map's `visibleLayers` state. */
 export const LAYER_SLUGS = {
     google: 'googleStreetView',
@@ -27,6 +29,15 @@ export const LAYER_SLUGS = {
 
 export type LayerSlug = keyof typeof LAYER_SLUGS;
 export type LayerKey = (typeof LAYER_SLUGS)[LayerSlug];
+
+/**
+ * The reverse of LAYER_SLUGS. The map state is keyed by LayerKey but the kill
+ * switch and the provider list are keyed by slug, so something has to translate
+ * — and deriving it here keeps the two lists from drifting apart.
+ */
+export const LAYER_KEY_TO_SLUG = Object.fromEntries(
+    (Object.keys(LAYER_SLUGS) as LayerSlug[]).map((slug) => [LAYER_SLUGS[slug], slug])
+) as Record<LayerKey, LayerSlug>;
 
 export const BASEMAPS = ['osm', 'carto', 'satellite', 'none'] as const;
 export type Basemap = (typeof BASEMAPS)[number];
@@ -102,6 +113,9 @@ export function parseMapHash(hash: string): MapUrlState | null {
                   .split(',')
                   .map((slug) => slug.trim().toLowerCase())
                   .filter((slug): slug is LayerSlug => slug in LAYER_SLUGS)
+                  // A link written before a provider was switched off must not
+                  // resurrect it.
+                  .filter((slug) => isProviderEnabled(slug))
                   .map((slug) => LAYER_SLUGS[slug]);
 
     const basemap = BASEMAPS.includes(basemapPart as Basemap) ? (basemapPart as Basemap) : 'osm';
@@ -134,4 +148,23 @@ export function formatMapHash(state: MapUrlState): string {
 /** Turns the `visibleLayers` state object into the list of enabled keys. */
 export function enabledLayerKeys(visible: Record<string, boolean>): LayerKey[] {
     return Object.values(LAYER_SLUGS).filter((key) => visible[key]);
+}
+
+/**
+ * The provider ids to query for a click, given the layer state.
+ *
+ * Lives here rather than next to the detection hook because it is pure and that
+ * hook imports Leaflet, which needs `window` and so cannot be loaded in a plain
+ * node test — and this is exactly the function a kill-switch test has to cover.
+ *
+ * Derived from LAYER_KEY_TO_SLUG. It used to strip suffixes off the key by hand
+ * ('googleStreetView' -> replace 'StreetView' -> 'google') with a special case
+ * for jaStreetView, which quietly depended on no two providers sharing a
+ * suffix — 'naverStreetView' only worked because it was tried after the others.
+ */
+export function activeProviderIds(visible: Record<string, boolean>): LayerSlug[] {
+    return (Object.keys(LAYER_KEY_TO_SLUG) as LayerKey[])
+        .filter((key) => visible[key])
+        .map((key) => LAYER_KEY_TO_SLUG[key])
+        .filter((slug) => isProviderEnabled(slug));
 }

--- a/src/lib/site.test.ts
+++ b/src/lib/site.test.ts
@@ -1,0 +1,157 @@
+/**
+ * site.test.ts
+ *
+ * Tests for the provider kill switch.
+ *
+ * This is the mechanism that lets a provider be taken off the site in about a
+ * minute if it ever asks us to stop. A kill switch that silently fails to kill
+ * is worse than not having one, so the cases below are deliberately about what
+ * must *not* happen: no killed provider in the user-facing list, no killed
+ * provider revived by an old shared link, no killed provider queried on click.
+ *
+ * DISABLED_PROVIDERS is read once at module load, so every case re-imports the
+ * module with a different environment via vi.resetModules().
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+async function loadSite(disabled?: string) {
+    vi.resetModules();
+    if (disabled === undefined) {
+        vi.stubEnv('NEXT_PUBLIC_DISABLED_PROVIDERS', '');
+    } else {
+        vi.stubEnv('NEXT_PUBLIC_DISABLED_PROVIDERS', disabled);
+    }
+    return import('./site');
+}
+
+async function loadUrlState(disabled?: string) {
+    await loadSite(disabled);
+    return import('./mapUrlState');
+}
+
+afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+});
+
+describe('isProviderEnabled', () => {
+    it('enables every provider when the variable is unset', async () => {
+        const { PROVIDERS, ENABLED_PROVIDERS } = await loadSite();
+        expect(ENABLED_PROVIDERS).toHaveLength(PROVIDERS.length);
+    });
+
+    it('disables a single named provider', async () => {
+        const { isProviderEnabled, ENABLED_PROVIDERS } = await loadSite('ja');
+        expect(isProviderEnabled('ja')).toBe(false);
+        expect(isProviderEnabled('google')).toBe(true);
+        expect(ENABLED_PROVIDERS.map((p) => p.id)).not.toContain('ja');
+    });
+
+    it('disables several, and tolerates whitespace and case', async () => {
+        const { isProviderEnabled } = await loadSite(' JA , Naver ');
+        expect(isProviderEnabled('ja')).toBe(false);
+        expect(isProviderEnabled('naver')).toBe(false);
+        expect(isProviderEnabled('apple')).toBe(true);
+    });
+
+    it('is case-insensitive on the queried id too', async () => {
+        const { isProviderEnabled } = await loadSite('ja');
+        expect(isProviderEnabled('JA')).toBe(false);
+    });
+
+    it('ignores empty entries rather than disabling everything', async () => {
+        const { ENABLED_PROVIDERS, PROVIDERS } = await loadSite(',,  ,');
+        expect(ENABLED_PROVIDERS).toHaveLength(PROVIDERS.length);
+    });
+
+    it('ignores an unknown id without disabling anything real', async () => {
+        const { ENABLED_PROVIDERS, PROVIDERS } = await loadSite('mapy,notaprovider');
+        expect(ENABLED_PROVIDERS).toHaveLength(PROVIDERS.length);
+    });
+});
+
+describe('coverage dates follow the kill switch', () => {
+    it('reports the oldest enabled date, not the oldest overall', async () => {
+        const all = await loadSite();
+        expect(all.oldestCoverageDate()).toBe('2025-02'); // Apple
+
+        const withoutApple = await loadSite('apple');
+        expect(withoutApple.oldestCoverageDate()).toBe('2025-09');
+    });
+
+    it('returns null when every collected provider is off', async () => {
+        const { oldestCoverageDate, newestCoverageDate } = await loadSite('apple,naver,ja');
+        expect(oldestCoverageDate()).toBeNull();
+        expect(newestCoverageDate()).toBeNull();
+    });
+
+    it('still reports a date when only live providers are disabled', async () => {
+        const { oldestCoverageDate } = await loadSite('google,bing,yandex');
+        expect(oldestCoverageDate()).toBe('2025-02');
+    });
+});
+
+describe('an old permalink cannot revive a killed provider', () => {
+    it('drops the killed slug while keeping the others', async () => {
+        const { parseMapHash } = await loadUrlState('ja');
+        const state = parseMapHash('#12/64.14/-21.89/ja,apple/osm');
+        expect(state?.layers).toEqual(['appleLookAround']);
+    });
+
+    it('yields an empty layer list when the link named only killed providers', async () => {
+        const { parseMapHash } = await loadUrlState('ja');
+        const state = parseMapHash('#12/64.14/-21.89/ja/osm');
+        // Empty, not null: the link did carry a layer section, so the map must
+        // honour it as "nothing on" rather than falling back to the defaults.
+        expect(state?.layers).toEqual([]);
+    });
+
+    it('keeps the slug when nothing is killed', async () => {
+        const { parseMapHash } = await loadUrlState();
+        const state = parseMapHash('#12/64.14/-21.89/ja/osm');
+        expect(state?.layers).toEqual(['jaStreetView']);
+    });
+
+    it('leaves position and basemap alone', async () => {
+        const { parseMapHash } = await loadUrlState('ja');
+        const state = parseMapHash('#12/64.14/-21.89/ja/carto');
+        expect(state?.zoom).toBe(12);
+        expect(state?.lat).toBeCloseTo(64.14, 5);
+        expect(state?.basemap).toBe('carto');
+    });
+});
+
+describe('click detection never queries a killed provider', () => {
+    it('filters it out even when the layer state says it is visible', async () => {
+        await loadSite('ja');
+        const { activeProviderIds } = await import('./mapUrlState');
+
+        // Deliberately inconsistent state — the kind a stale bundle or a
+        // devtools edit could produce. Detection must still refuse.
+        const ids = activeProviderIds({ jaStreetView: true, googleStreetView: true });
+        expect(ids).toEqual(['google']);
+    });
+
+    it('passes everything through when nothing is killed', async () => {
+        await loadSite();
+        const { activeProviderIds } = await import('./mapUrlState');
+        const ids = activeProviderIds({ jaStreetView: true, appleLookAround: true });
+        expect(ids.sort()).toEqual(['apple', 'ja']);
+    });
+});
+
+describe('the layer key/slug tables stay in step', () => {
+    it('maps every key back to its slug', async () => {
+        const { LAYER_SLUGS, LAYER_KEY_TO_SLUG } = await loadUrlState();
+        for (const [slug, key] of Object.entries(LAYER_SLUGS)) {
+            expect(LAYER_KEY_TO_SLUG[key]).toBe(slug);
+        }
+    });
+
+    it('covers exactly the providers declared in site.ts', async () => {
+        const { PROVIDERS } = await loadSite();
+        const { LAYER_SLUGS } = await import('./mapUrlState');
+        expect(Object.keys(LAYER_SLUGS).sort()).toEqual(PROVIDERS.map((p) => p.id).sort());
+    });
+});

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -15,10 +15,6 @@ export const SITE_URL = 'https://streetradar.app';
 
 export const SITE_NAME = 'StreetRadar';
 
-export const SITE_DESCRIPTION =
-    'See where Street View imagery exists worldwide. Coverage from Google, Apple Look Around, ' +
-    'Bing Streetside, Yandex, Naver and Já 360 on a single map.';
-
 /**
  * When the coverage data was last rebuilt, per provider.
  *
@@ -50,50 +46,136 @@ export interface Provider {
     /** One sentence a visitor who has never heard of it can use. */
     blurb: string;
     source: 'live' | 'collected';
+    logo: string;
+    /** Short form for badges and tight UI, where the full name will not fit. */
+    shortName: string;
 }
 
 export const PROVIDERS: Provider[] = [
     {
         id: 'google',
+        logo: '/images/providers/google.svg',
+        shortName: 'Google',
         name: 'Google Street View',
         blurb: 'The largest network by far, covering most of the road network in over 100 countries.',
         source: 'live',
     },
     {
         id: 'apple',
+        logo: '/images/providers/apple.svg',
+        shortName: 'Apple',
         name: 'Apple Look Around',
         blurb: "Apple's equivalent, launched in 2019 and still limited to a few dozen countries.",
         source: 'collected',
     },
     {
         id: 'bing',
+        logo: '/images/providers/bing.svg',
+        shortName: 'Bing',
         name: 'Bing Streetside',
         blurb: "Microsoft's network, concentrated in North America and Western Europe.",
         source: 'live',
     },
     {
         id: 'yandex',
+        logo: '/images/providers/yandex.svg',
+        shortName: 'Yandex',
         name: 'Yandex Panoramas',
         blurb: 'The most detailed coverage of Russia, Central Asia and the Caucasus.',
         source: 'live',
     },
     {
         id: 'naver',
+        logo: '/images/providers/naver.svg',
+        shortName: 'Naver',
         name: 'Naver Street View',
         blurb: 'Dense coverage of South Korea, where Google’s is restricted.',
         source: 'collected',
     },
     {
         id: 'ja',
+        logo: '/images/providers/ja.svg',
+        shortName: 'Já 360',
         name: 'Já 360',
         blurb: 'An Icelandic directory service whose imagery covers 59.6% of the road network.',
         source: 'collected',
     },
 ];
 
-/** The oldest of the per-provider dates — what the site as a whole can claim. */
-export function oldestCoverageDate(): string {
-    return Object.values(COVERAGE_UPDATED).sort()[0];
+/**
+ * Providers switched off at build time, as a comma-separated list of the ids
+ * above — `NEXT_PUBLIC_DISABLED_PROVIDERS=ja,naver`.
+ *
+ * This exists so that a provider can be taken off the site without a code
+ * change: set the variable in Vercel, redeploy, done in about a minute. Six
+ * providers are reached through undocumented endpoints, and if any of them ever
+ * asks us to stop, the ability to comply immediately is worth more than the
+ * layer is. Without it the only options are a rushed commit or taking the whole
+ * site down.
+ *
+ * NEXT_PUBLIC_ because the map is client-rendered, so the value is inlined into
+ * the bundle at build time rather than read at runtime. That is the trade for
+ * not having to run a config service.
+ *
+ * A disabled provider is filtered out of the layer list, the layer control, the
+ * click-detection query, and the URL hash — so no request to it can originate
+ * from the deployed site, and an old shared link cannot switch it back on.
+ */
+const DISABLED_PROVIDERS: ReadonlySet<string> = new Set(
+    (process.env.NEXT_PUBLIC_DISABLED_PROVIDERS ?? '')
+        .split(',')
+        .map((id) => id.trim().toLowerCase())
+        .filter(Boolean)
+);
+
+/** Whether a provider id (`google`, `apple`, `ja`, …) is currently served. */
+export function isProviderEnabled(id: string): boolean {
+    return !DISABLED_PROVIDERS.has(id.toLowerCase());
+}
+
+/** PROVIDERS minus anything switched off. Use this for anything user-facing. */
+export const ENABLED_PROVIDERS: Provider[] = PROVIDERS.filter((provider) =>
+    isProviderEnabled(provider.id)
+);
+
+/** "A, B and C" — for prose that has to name the providers. */
+export function listProviderNames(providers: Provider[] = ENABLED_PROVIDERS): string {
+    const names = providers.map((provider) => provider.name);
+    if (names.length <= 1) return names[0] ?? '';
+    return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`;
+}
+
+/**
+ * Derived rather than written out, so that switching a provider off also stops
+ * the site claiming to cover it in its own meta description, Open Graph tags and
+ * structured data. Those strings are what search engines and social platforms
+ * cache, so a stale one outlives the deploy that caused it.
+ */
+export const SITE_DESCRIPTION = `See where Street View imagery exists worldwide. Coverage from ${listProviderNames()} on a single map.`;
+
+/**
+ * The oldest of the per-provider dates — what the site as a whole can claim.
+ *
+ * Only counts providers still switched on: if the layer whose data is oldest
+ * gets disabled, the footer would otherwise keep apologising for data that is
+ * no longer being served.
+ */
+export function oldestCoverageDate(): string | null {
+    return enabledCoverageDates()[0] ?? null;
+}
+
+/** The newest of the per-provider dates, for deciding whether "or newer" applies. */
+export function newestCoverageDate(): string | null {
+    const dates = enabledCoverageDates();
+    return dates[dates.length - 1] ?? null;
+}
+
+/** Sorted rebuild dates of the collected providers that are still switched on. */
+function enabledCoverageDates(): string[] {
+    return Object.entries(COVERAGE_UPDATED)
+        .filter(([id]) => isProviderEnabled(id))
+        .map(([, date]) => date)
+        .sort();
 }
 
 /** Renders a YYYY-MM string as "February 2025". */

--- a/src/services/streetViewLayer.tsx
+++ b/src/services/streetViewLayer.tsx
@@ -15,6 +15,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import type { LayerSlug } from '@/lib/mapUrlState';
 import L from 'leaflet';
 import { StreetViewService } from '@/services/streetViewService';
 import { createBingTileLayer } from './bingTileLayer';
@@ -31,7 +32,7 @@ import { createNaverPMTilesLayer } from './naverPMTilesLayerNew';
  */
 interface StreetViewLayerProps {
     map: L.Map | null;
-    provider: 'google' | 'apple' | 'bing' | 'yandex' | 'naver' | 'ja';
+    provider: LayerSlug;
     visible: boolean;
 }
 

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,20 @@
+/**
+ * vitest.config.ts
+ *
+ * There was no vitest config at all. That worked only for as long as no tested
+ * file imported through the `@/` alias — the moment one did, the suite failed to
+ * resolve it and reported "0 test", which reads like a passing run at a glance.
+ *
+ * The alias mirrors `paths` in tsconfig.json. Keep the two in step.
+ */
+
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+export default defineConfig({
+    resolve: {
+        alias: {
+            '@': fileURLToPath(new URL('./src', import.meta.url)),
+        },
+    },
+});


### PR DESCRIPTION
Phase 6: make it possible to comply with a takedown in about a minute, instead of choosing between a rushed commit and taking the site down.

## The switch

`NEXT_PUBLIC_DISABLED_PROVIDERS=ja,naver` in Vercel plus a redeploy. A killed provider disappears from:

- the layer control, and the layer component is **not mounted at all** — so not one tile request can originate from the deployed site
- the click-detection query, filtered separately rather than trusting the layer state to be consistent
- the URL hash, so an old shared permalink cannot switch it back on
- the home page and `/map` provider lists
- the meta description, Open Graph card and JSON-LD — the strings search engines and social platforms cache, and which therefore outlive the deploy that fixed them

### Verified in a browser, both directions

| | `NEXT_PUBLIC_DISABLED_PROVIDERS=ja` | unset |
|---|---|---|
| `/map#8/64.14/-21.89/ja,google/osm` | hash rewritten to `…/google/osm` | Já switched on |
| requests to `ja360` / `ja.is` | **0** | 26 range requests to `ja360.pmtiles` |
| layer control entries | 5 | 6 |
| mentions of `Já` across `/`, `/map`, `/analytics` | 0, 0, 0 | present |
| Google tiles | loading | loading |

Plus 17 new unit tests covering the parsing, the coverage-date arithmetic, permalink stripping, and detection filtering with deliberately inconsistent layer state.

## Three things that fell out of doing it

**`activeProviderIds` was fragile.** It derived provider ids by stripping suffixes off the state key — `'googleStreetView'` minus `'StreetView'` — with a hardcoded special case for `jaStreetView`. `'naverStreetView'` only worked because it happened to be tried after the others. It is now a lookup on a `LAYER_KEY_TO_SLUG` table derived from `LAYER_SLUGS`, and it moved out of the detection hook into `mapUrlState` — it is pure, and that hook imports Leaflet, which needs `window` and so cannot be loaded in a node test.

**The provider list existed three times.** `lib/site.ts` claimed to be the source of truth for it while hardcoded copies lived in the home page, the map control and the Open Graph card. Now one list, with `shortName` and `logo` on it.

**There was no vitest config at all.** That worked only while no tested file imported through the `@/` alias. The moment `mapUrlState` did, the suite failed to resolve it and reported `0 test` — which reads like a passing run at a glance. Config added, alias mirrored from tsconfig.

## The runbook

`docs/RUNBOOK-takedown.md`. Written because a kill switch is only useful if the steps around it exist before they are needed, and because the R2 half cannot be done from the codebase at all.

Measured while writing it — the tile host has **no protection of any kind**:

- anonymous range request, no `Referer` → `206`
- any `Referer` accepted
- **CORS policy is `access-control-allow-origin: *`**, so any website can embed 16.36 GB of tiles in its visitors' browsers on our bandwidth

That last one is the actual leak, more than `curl` is. The runbook ranks the three possible controls by what they accomplish rather than how protective they sound: tightening CORS is the only one genuinely *enforced* (the browser refuses), rate-limiting is the only one that cannot be defeated by forging a header, and a `Referer` rule is called out as not worth doing on its own. It also records that the R2 public development URL must be off, since a live `pub-<hash>.r2.dev` URL bypasses the custom domain and makes every other rule decorative.

None of that is applied here: the Cloudflare OAuth token wrangler holds grants `zone (read)`, and these need bucket-level R2 write plus zone rules edit. The needed scopes are named in the doc.

## Not included

`www.streetradar.app` still returns 526 — no `www` record in the zone, so it resolves via a wildcard to Vercel, which has no certificate for that name. Recorded in §3 of the runbook; the fix is one field in Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)